### PR TITLE
Add checks permission to job to be able to post status

### DIFF
--- a/.github/workflows/report_status.yml
+++ b/.github/workflows/report_status.yml
@@ -12,6 +12,7 @@ jobs:
   set_status:
     runs-on: ubuntu-latest
     permissions:
+      checks: write
       statuses: write 
     steps:
       - name: "Report Status"


### PR DESCRIPTION
## Description

- I think this is the missing permission.
- This job should allow the manually triggered job on the `changeset-release/main` branch to report the status correctly so the branch checks will pass.
