### PR TITLE
Mount iframe on receiving custom event when in autohide mode

### DIFF
--- a/.changeset/violet-actors-drive.md
+++ b/.changeset/violet-actors-drive.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": minor
+---
+
+When in autohide mode, mount the Mash iframe after receiving a custom event (rather than querying the DOM)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,3 +8,8 @@
 
 - Closes #XXX
 - Closes #YYY
+
+### Testing Completed
+
+- I did thing X to test thing A...
+- I did thing Y to test thing B...

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "clean": "rm -f tsconfig.tsbuildinfo && rm -rf dist",
     "build": "tsc --build",
+    "build:watch": "tsc --build --watch",
     "fmt": "prettier --check src/",
     "fmt:fix": "prettier --write src/",
     "lint": "tsc --build && eslint .",

--- a/packages/client-sdk/src/@types/node.d.ts
+++ b/packages/client-sdk/src/@types/node.d.ts
@@ -1,0 +1,35 @@
+import "node:test"; // trigger declaration merging
+
+// Extend the existing node types with the builtin test runner's new mocking capabilities.
+// These were introduced in node v19. Once their types are defined in @types/node we can drop.
+// This is a subset of the mocking functionality offered, but should be enough for now when used
+// with before/after constructs.
+declare module "node:test" {
+  export const mock: MockTracker;
+
+  interface MockFnOptions {
+    times?: number;
+  }
+
+  interface MockMethodOptions {
+    getter?: boolean;
+    setter?: boolean;
+    times?: number;
+  }
+
+  // https://nodejs.org/api/test.html#class-mocktracker
+  interface MockTracker {
+    fn<T>(
+      original?: T,
+      implementation?: T,
+      options?: MockFnOptions,
+    ): T & { mock: MockFunctionContext };
+    reset: () => void;
+    restoreAll: () => void;
+  }
+
+  // https://nodejs.org/api/test.html#class-mockfunctioncontext
+  interface MockFunctionContext {
+    callCount: () => number;
+  }
+}

--- a/packages/client-sdk/src/Mash.test.ts
+++ b/packages/client-sdk/src/Mash.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { beforeEach, test, mock } from "node:test";
+
+import Mash from "./Mash.js";
+import { MashEvent } from "./events.js";
+import { createDOM } from "./tests/dom.js";
+
+function mockMethod<T>(obj: unknown, methodName: string, fn: T) {
+  // Note: mock.method should in theory work, but node < v19.3.0 has a bug where it doesn't search up
+  // the prototype chain for methods. Fix here: https://github.com/nodejs/node/commit/929aada39d
+  // As the fix is still unreleased at time of writing, usuing Object.defineProperty directly for now
+  const _init = mock.fn(fn);
+  Object.defineProperty(obj, "_init", { value: _init });
+  return _init;
+}
+
+// Note: using test instead of describe/it so that we can await the result of the subtests
+// https://nodejs.org/api/test.html#testname-options-fn
+test("Mash", async t => {
+  beforeEach(() => {
+    createDOM();
+  });
+
+  // Tests that mounting is initiated immediately when not autohiding
+  await t.test("initializes immediately when not autohiding", async () => {
+    const mash = new Mash({
+      earnerID: "abc123",
+    });
+
+    const _init = mockMethod(mash, "_init", async () => null);
+    await mash.init();
+    assert.strictEqual(_init.mock.callCount(), 1);
+  });
+
+  // Tests that mounting is initiated only on receiving an event when autohiding
+  await t.test(
+    "initializes after widgets connect when autohiding",
+    async () => {
+      const mash = new Mash({
+        earnerID: "abc123",
+        autoHide: true,
+      });
+
+      const _init = mockMethod(mash, "_init", async () => null);
+
+      const initialized = mash.init();
+      assert.strictEqual(_init.mock.callCount(), 0);
+      // Make sure multiple events don't cause issues
+      for (let i = 0; i < 3; i++) {
+        window.dispatchEvent(new window.CustomEvent(MashEvent.WidgetConnected));
+      }
+      await initialized;
+      assert.strictEqual(_init.mock.callCount(), 1);
+    },
+  );
+});

--- a/packages/client-sdk/src/Mash.test.ts
+++ b/packages/client-sdk/src/Mash.test.ts
@@ -6,7 +6,7 @@ import { MashEvent } from "./events.js";
 import { createDOM } from "./tests/dom.js";
 
 function mockMethod<T>(obj: unknown, methodName: string, fn: T) {
-  // Note: mock.method should in theory work, but node < v19.3.0 has a bug where it doesn't search up
+  // Note: mock.method should in theory work, but node <= v19.3.0 has a bug where it doesn't search up
   // the prototype chain for methods. Fix here: https://github.com/nodejs/node/commit/929aada39d
   // As the fix is still unreleased at time of writing, usuing Object.defineProperty directly for now
   const _init = mock.fn(fn);

--- a/packages/client-sdk/src/Mash.test.ts
+++ b/packages/client-sdk/src/Mash.test.ts
@@ -47,7 +47,9 @@ test("Mash", async t => {
       assert.equal(_init.mock.callCount(), 0);
       // Make sure multiple events don't cause issues
       for (let i = 0; i < 3; i++) {
-        window.dispatchEvent(new window.CustomEvent(MashEvent.WidgetConnected));
+        window.dispatchEvent(
+          new window.CustomEvent(MashEvent.WebComponentConnected),
+        );
       }
       await initialized;
       assert.equal(_init.mock.callCount(), 1);

--- a/packages/client-sdk/src/Mash.test.ts
+++ b/packages/client-sdk/src/Mash.test.ts
@@ -29,7 +29,7 @@ test("Mash", async t => {
 
     const _init = mockMethod(mash, "_init", async () => null);
     await mash.init();
-    assert.strictEqual(_init.mock.callCount(), 1);
+    assert.equal(_init.mock.callCount(), 1);
   });
 
   // Tests that mounting is initiated only on receiving an event when autohiding
@@ -44,13 +44,13 @@ test("Mash", async t => {
       const _init = mockMethod(mash, "_init", async () => null);
 
       const initialized = mash.init();
-      assert.strictEqual(_init.mock.callCount(), 0);
+      assert.equal(_init.mock.callCount(), 0);
       // Make sure multiple events don't cause issues
       for (let i = 0; i < 3; i++) {
         window.dispatchEvent(new window.CustomEvent(MashEvent.WidgetConnected));
       }
       await initialized;
-      assert.strictEqual(_init.mock.callCount(), 1);
+      assert.equal(_init.mock.callCount(), 1);
     },
   );
 });

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -153,9 +153,7 @@ class Mash {
         "[MASH] Autohide is enabled - waiting for a web component widget to connect",
       );
       return this.widgetConnected.then(() => {
-        console.info(
-          "[MASH] A web component widget connected to the SDK - mounting",
-        );
+        console.info("[MASH] A web component widget connected - mounting");
         return this._init(settings);
       });
     }

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -45,7 +45,7 @@ class Mash {
     this.widgetConnected = new Promise<void>(res => {
       // Note: subsequent calls to res will be a no-op, which allows us to ignore more than the initial received event.
       // See here: https://stackoverflow.com/questions/20328073#comment92822918_29491617
-      window.addEventListener(MashEvent.WidgetConnected, () => res());
+      window.addEventListener(MashEvent.WebComponentConnected, () => res());
     });
 
     const defaultConfiguration: MashWebAPI.EarnerCustomizationConfiguration = {

--- a/packages/client-sdk/src/config.ts
+++ b/packages/client-sdk/src/config.ts
@@ -28,10 +28,10 @@ const DEFAULT_WIDGETS_CONFIG: WidgetConfig = {
 
 export default function parse(config: PartialConfig): Config {
   return {
+    earnerID: config.earnerID,
     api: config.api || DefaultAPIBaseURL,
     autoHide: config.autoHide ?? false,
-    earnerID: config.earnerID,
     walletURL: config.walletURL || DefaultWalletURL,
-    widgets: Object.assign({}, DEFAULT_WIDGETS_CONFIG, config.widgets),
+    widgets: { ...DEFAULT_WIDGETS_CONFIG, ...config.widgets },
   };
 }

--- a/packages/client-sdk/src/events.ts
+++ b/packages/client-sdk/src/events.ts
@@ -2,5 +2,5 @@
  * Custom events emitted and/or reacted to by the SDK.
  */
 export enum MashEvent {
-  WidgetConnected = "@getmash/client-sdk:widget-connected",
+  WebComponentConnected = "@getmash/client-sdk:web-component-connected",
 }

--- a/packages/client-sdk/src/events.ts
+++ b/packages/client-sdk/src/events.ts
@@ -1,0 +1,6 @@
+/**
+ * Custom events emitted and/or reacted to by the SDK.
+ */
+export enum MashEvent {
+  WidgetConnected = "@getmash/client-sdk:widget-connected",
+}

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -54,6 +54,8 @@ const replacePostMessage = (sourceWindow: Window | null) => {
 };
 
 // JSDOM does not implement the matchMedia function on window.
+// Mock based on Jest-documented workaround:
+// https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 function mockMatchMedia(mobile = false) {
   Object.defineProperty(window, "matchMedia", {
     value: (query: string) => ({

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -63,6 +63,7 @@ const IFRAME_STYLE = {
   width: "100%",
   height: "100%",
   "background-color": "inherit !important",
+  "color-scheme": "normal",
 };
 
 export type EventMessage<T = Record<string, unknown>> = {

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -97,7 +97,14 @@ export const IFRAME_NAME = "mash_wallet";
 
 export default class IFrame {
   readonly src: URL;
-  mounted = false;
+
+  private _mounted = false;
+  get mounted() {
+    return this._mounted;
+  }
+  private set mounted(val: boolean) {
+    this._mounted = val;
+  }
 
   private open = false;
   private notificationCount = 0;

--- a/packages/client-sdk/src/index.ts
+++ b/packages/client-sdk/src/index.ts
@@ -18,3 +18,5 @@ export {
   Events as IFrameEvents,
   IFRAME_NAME as MashIFrameName,
 } from "./iframe/IFrame.js";
+
+export { MashEvent } from "./events.js";

--- a/packages/client-sdk/src/widgets/widgets.test.ts
+++ b/packages/client-sdk/src/widgets/widgets.test.ts
@@ -2,46 +2,9 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { createDOM } from "../tests/dom.js";
-import {
-  injectWidgets,
-  isWidgetOnPage,
-  Widgets,
-  DeprecatedWidgets,
-} from "./widgets.js";
+import { injectWidgets, Widgets } from "./widgets.js";
 
 describe("widgets", () => {
-  describe("isWidgetOnPage", () => {
-    it("no mash widgets, should return false", async () => {
-      createDOM();
-      const result = await isWidgetOnPage();
-      assert.equal(result, false);
-    });
-    it("mash widgets exists, should return true", async () => {
-      createDOM();
-
-      const widgets = Object.values(Widgets);
-      const widget = widgets[Math.floor(Math.random() * widgets.length)];
-
-      const wc = window.document.createElement(widget.element);
-      window.document.body.appendChild(wc);
-
-      const result = await isWidgetOnPage();
-      assert.equal(result, true);
-    });
-    it("old mash widget exists, should return true", async () => {
-      createDOM();
-
-      const widget =
-        DeprecatedWidgets[Math.floor(Math.random() * DeprecatedWidgets.length)];
-
-      const wc = window.document.createElement(widget);
-      window.document.body.appendChild(wc);
-
-      const result = await isWidgetOnPage();
-      assert.equal(result, true);
-    });
-  });
-
   describe("injectWidgets", () => {
     it("should inject all widgets", () => {
       createDOM();

--- a/packages/client-sdk/src/widgets/widgets.ts
+++ b/packages/client-sdk/src/widgets/widgets.ts
@@ -47,36 +47,3 @@ export function injectWidgets(baseURL: string) {
   });
   window.document.head.append(...scripts);
 }
-
-function _isWidgetOnPage() {
-  const widgets = Object.values(Widgets);
-
-  // Check for new widgets
-  for (let i = 0; i < widgets.length; i++) {
-    const el = window.document.querySelector(widgets[i].element);
-    if (el) return true;
-  }
-
-  // Check for old widgets
-  for (let i = 0; i < DeprecatedWidgets.length; i++) {
-    const el = window.document.querySelector(DeprecatedWidgets[i]);
-    if (el) return true;
-  }
-
-  return false;
-}
-
-/**
- * Check if a known Mash Widget exists on the page.
- */
-export function isWidgetOnPage(): Promise<boolean> {
-  return new Promise(resolve => {
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", () =>
-        resolve(_isWidgetOnPage()),
-      );
-      return;
-    }
-    resolve(_isWidgetOnPage());
-  });
-}

--- a/packages/jsonrpc-engine/package.json
+++ b/packages/jsonrpc-engine/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "clean": "rm -f tsconfig.tsbuildinfo && rm -rf dist",
     "build": "tsc --build",
+    "build:watch": "tsc --build --watch",
     "fmt": "prettier --check src/",
     "fmt:fix": "prettier --write src/",
     "lint": "tsc --build && eslint .",

--- a/packages/post-message/package.json
+++ b/packages/post-message/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rm -f tsconfig.tsbuildinfo && rm -rf dist",
     "build": "tsc --build",
+    "build:watch": "tsc --build --watch",
     "fmt": "prettier --check src/",
     "fmt:fix": "prettier --write src/",
     "lint": "tsc --build && eslint .",

--- a/packages/post-message/src/PostMessageEngine.test.ts
+++ b/packages/post-message/src/PostMessageEngine.test.ts
@@ -7,7 +7,7 @@ import PostMessageEngine, { PostMessageEvent } from "./PostMessageEngine.js";
 
 describe("PostMessageEngine", () => {
   beforeEach(() => {
-    // @ts-expect-errorJSDOM Window mismatch
+    // @ts-expect-error JSDOM Window mismatch
     global.window = new JSDOM("").window;
     // Replaces the global window instance's postMessage implementation in order to
     // set event source or origin which our post message engine depends on to filter messages: https://github.com/jsdom/jsdom/issues/2745


### PR DESCRIPTION
## Description

Previously, when `autoHide` was `true`, widget web components added to the DOM after `DOMContentLoaded` did not result in the wallet iframe being mounted, as the `Mash` class queried the DOM manually once. This update allows widgets to be injected dynamically at any time in `autoHide` mode and still have the iframe appear.

Note: this change also removes that initial DOM query, as it'll be more maintainable in the long run to put the onus on consuming code to notify `Mash` that it's being used, rather than enumerating every possible consumer (i.e. all Mash web components). Therefore, this requires any web component definitions to be registered _after_ `Mash` is constructed (which is the default with `injectWidgets`), as the event listener needs to exist before the custom web component is instantiated. In the future, we can explore loosening this restriction by ex. updating `Mash` to emit its own "created" event, allowing consuming widgets to wait if `window.Mash` isn't already ready before emitting their own events.

## Additional Changes
- Updated PR template to include testing section.
- Added `build:watch` yarn scripts for all packages.
- Fixed issue with iframe `color-scheme` – previously, the iframe was shown with a white background/border when on a host page with `color-scheme: dark`.
- Updated `IFrame` class's `mounted` flag to be readonly from outside the class.

## Testing Completed

- Created tests in `Mash.test.ts` for verifying flow of non-autohide & autohide behaviour.
- Verified in test web app that iframe is mounted with `autoHide` set to both `true` and `false`. (Added an artificial timeout after which the web component widgets were added to the DOM, and confirmed the iframe is mounted only after this when in autohide mode.)