### PR TITLE
Use autohide setting from remote config

### DIFF
--- a/.changeset/spicy-chairs-dance.md
+++ b/.changeset/spicy-chairs-dance.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": minor
+---
+
+Use autohide setting from remote config

--- a/packages/client-sdk/src/api/routes.ts
+++ b/packages/client-sdk/src/api/routes.ts
@@ -85,6 +85,7 @@ export type EarnerCustomizationConfiguration = {
   walletButtonPosition: WalletButtonPosition;
   theme: Theme;
   boostConfigurations: BoostConfiguration[];
+  autoHide: boolean;
 };
 
 export type Earner = {

--- a/packages/client-sdk/src/config.test.ts
+++ b/packages/client-sdk/src/config.test.ts
@@ -13,7 +13,7 @@ describe("Config", () => {
     const result = parse({ earnerID: "1" });
     assert.deepEqual<Config>(result, {
       api: DefaultAPIBaseURL,
-      autoHide: false,
+      autoHide: undefined,
       earnerID: "1",
       walletURL: DefaultWalletURL,
       widgets: {
@@ -28,7 +28,7 @@ describe("Config", () => {
     const config: Config = {
       api: "http://test.com",
       earnerID: "1",
-      autoHide: false,
+      autoHide: undefined,
       walletURL: "testsite",
       widgets: {
         baseURL: "tester.com",

--- a/packages/client-sdk/src/config.ts
+++ b/packages/client-sdk/src/config.ts
@@ -8,10 +8,12 @@ type WidgetConfig = {
 
 export type Config = {
   api: string;
-  autoHide: boolean;
   earnerID: string;
   walletURL: string;
   widgets: WidgetConfig;
+  // Local properties that are replicated serverside in the remote
+  // config. Specifying them overrides remote (local takes precendence).
+  autoHide?: boolean;
 };
 
 export type PartialConfig = PartialDeep<Config> & { earnerID: string };
@@ -30,8 +32,8 @@ export default function parse(config: PartialConfig): Config {
   return {
     earnerID: config.earnerID,
     api: config.api || DefaultAPIBaseURL,
-    autoHide: config.autoHide ?? false,
     walletURL: config.walletURL || DefaultWalletURL,
     widgets: { ...DEFAULT_WIDGETS_CONFIG, ...config.widgets },
+    autoHide: config.autoHide,
   };
 }


### PR DESCRIPTION
## Description

Updates autohide logic to pull down remote config. If local autohide is set, it will take precedence.

## Additional Info

### Testing Completed

- Verified locally that setting autohide in the remote config results in autohide being enabled.
- Verified locally that the remote config autohide setting can be overridden by `Mash` config.
