### PR TITLE
Simplify paths settings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,5 @@
 {
-  "compilerOptions": {
-    "paths": {
-      "@mash/jsonrpc-engine": [
-        "./packages/jsonrpc-engine"
-      ],
-      "@mash/post-message": [
-        "./packages/post-message"
-      ]
-    }
-  },
-  "exclude": [
-    "node_modules"
-  ],
+  "files": [],
   "references": [
     {
       "path": "packages/client-sdk"


### PR DESCRIPTION
Trying to get to the bottom of LSP's adding `/src` when they add import statements. I think this bare-minimum config works for most LSPs?