### PR TITLE
Add modal iframe to client sdk

### DIFF
--- a/.changeset/lucky-frogs-talk.md
+++ b/.changeset/lucky-frogs-talk.md
@@ -2,4 +2,4 @@
 "@getmash/client-sdk": minor
 ---
 
-Adds a modal iframe that gets mounted in hidden visibility with the ability to show via a modal open event.
+Adds a preboarding iframe that gets mounted in hidden visibility with the ability to show via open/close events

--- a/.changeset/lucky-frogs-talk.md
+++ b/.changeset/lucky-frogs-talk.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": minor
+---
+
+Adds a modal iframe that gets mounted in hidden visibility with the ability to show via a modal open event.

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -40,7 +40,10 @@ class Mash {
 
   constructor(config: PartialConfig) {
     this.localConfig = parseConfig(config);
-    this.iframe = new IFrame(this.localConfig.walletURL, this.localConfig.modalURL);
+    this.iframe = new IFrame(
+      this.localConfig.walletURL,
+      this.localConfig.modalURL,
+    );
 
     // Listen for connect events from widgets
     this.widgetConnected = new Promise<void>(res => {

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -43,7 +43,9 @@ class Mash {
   constructor(config: PartialConfig) {
     this.localConfig = parseConfig(config);
     this.iframe = new IFrame(this.localConfig.walletURL);
-    this.preboardIFrame = new PreboardingIFrame(this.localConfig.preboardingURL);
+    this.preboardIFrame = new PreboardingIFrame(
+      this.localConfig.preboardingURL,
+    );
 
     // Listen for connect events from widgets
     this.widgetConnected = new Promise<void>(res => {

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -40,7 +40,7 @@ class Mash {
 
   constructor(config: PartialConfig) {
     this.localConfig = parseConfig(config);
-    this.iframe = new IFrame(this.localConfig.walletURL);
+    this.iframe = new IFrame(this.localConfig.walletURL, this.localConfig.modalURL);
 
     // Listen for connect events from widgets
     this.widgetConnected = new Promise<void>(res => {

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -4,6 +4,7 @@ import * as MashWebAPI from "./api/routes.js";
 import parseConfig, { PartialConfig, Config } from "./config.js";
 import { MashEvent } from "./events.js";
 import IFrame from "./iframe/IFrame.js";
+import { ModalIFrame } from "./iframe/ModalIFrame.js";
 import {
   getWalletPosition,
   WalletPosition,
@@ -24,6 +25,7 @@ export type MashSettings = {
 class Mash {
   private rpcAPI: MashRPCAPI | null = null;
   private iframe: IFrame;
+  private modalIframe: ModalIFrame;
   private initialized = false;
   /**
    * Configuration set in the local source.
@@ -40,10 +42,8 @@ class Mash {
 
   constructor(config: PartialConfig) {
     this.localConfig = parseConfig(config);
-    this.iframe = new IFrame(
-      this.localConfig.walletURL,
-      this.localConfig.modalURL,
-    );
+    this.iframe = new IFrame(this.localConfig.walletURL);
+    this.modalIframe = new ModalIFrame(this.localConfig.modalURL);
 
     // Listen for connect events from widgets
     this.widgetConnected = new Promise<void>(res => {
@@ -254,6 +254,7 @@ class Mash {
       };
 
       this.iframe.mount(onIframeLoaded, position);
+      this.modalIframe.mount();
     });
   }
 }

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -4,7 +4,7 @@ import * as MashWebAPI from "./api/routes.js";
 import parseConfig, { PartialConfig, Config } from "./config.js";
 import { MashEvent } from "./events.js";
 import IFrame from "./iframe/IFrame.js";
-import { ModalIFrame } from "./iframe/ModalIFrame.js";
+import { PreboardingIFrame } from "./iframe/PreboardingIFrame.js";
 import {
   getWalletPosition,
   WalletPosition,
@@ -25,7 +25,7 @@ export type MashSettings = {
 class Mash {
   private rpcAPI: MashRPCAPI | null = null;
   private iframe: IFrame;
-  private modalIframe: ModalIFrame;
+  private preboardIFrame: PreboardingIFrame;
   private initialized = false;
   /**
    * Configuration set in the local source.
@@ -43,7 +43,7 @@ class Mash {
   constructor(config: PartialConfig) {
     this.localConfig = parseConfig(config);
     this.iframe = new IFrame(this.localConfig.walletURL);
-    this.modalIframe = new ModalIFrame(this.localConfig.modalURL);
+    this.preboardIFrame = new PreboardingIFrame(this.localConfig.preboardingURL);
 
     // Listen for connect events from widgets
     this.widgetConnected = new Promise<void>(res => {
@@ -254,7 +254,7 @@ class Mash {
       };
 
       this.iframe.mount(onIframeLoaded, position);
-      this.modalIframe.mount();
+      this.preboardIFrame.mount();
     });
   }
 }

--- a/packages/client-sdk/src/config.test.ts
+++ b/packages/client-sdk/src/config.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+
 import { describe, it } from "node:test";
 
 import parse, {
   Config,
   DefaultAPIBaseURL,
+  DefaultModalURL,
   DefaultWalletURL,
   DefaultWidgetBaseURL,
 } from "./config.js";
@@ -16,6 +18,7 @@ describe("Config", () => {
       autoHide: undefined,
       earnerID: "1",
       walletURL: DefaultWalletURL,
+      modalURL: DefaultModalURL,
       widgets: {
         baseURL: DefaultWidgetBaseURL,
         injectTheme: true,
@@ -30,6 +33,7 @@ describe("Config", () => {
       earnerID: "1",
       autoHide: undefined,
       walletURL: "testsite",
+      modalURL: "testsitemodal",
       widgets: {
         baseURL: "tester.com",
         injectTheme: false,

--- a/packages/client-sdk/src/config.test.ts
+++ b/packages/client-sdk/src/config.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-
 import { describe, it } from "node:test";
 
 import parse, {

--- a/packages/client-sdk/src/config.test.ts
+++ b/packages/client-sdk/src/config.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import parse, {
   Config,
   DefaultAPIBaseURL,
-  DefaultModalURL,
+  DefaultPreboardingURL,
   DefaultWalletURL,
   DefaultWidgetBaseURL,
 } from "./config.js";
@@ -17,7 +17,7 @@ describe("Config", () => {
       autoHide: undefined,
       earnerID: "1",
       walletURL: DefaultWalletURL,
-      modalURL: DefaultModalURL,
+      preboardingURL: DefaultPreboardingURL,
       widgets: {
         baseURL: DefaultWidgetBaseURL,
         injectTheme: true,
@@ -32,7 +32,7 @@ describe("Config", () => {
       earnerID: "1",
       autoHide: undefined,
       walletURL: "testsite",
-      modalURL: "testsitemodal",
+      preboardingURL: "testpreboardingsite",
       widgets: {
         baseURL: "tester.com",
         injectTheme: false,

--- a/packages/client-sdk/src/config.ts
+++ b/packages/client-sdk/src/config.ts
@@ -10,7 +10,7 @@ export type Config = {
   api: string;
   earnerID: string;
   walletURL: string;
-  modalURL: string;
+  preboardingURL: string;
   widgets: WidgetConfig;
   // Local properties that are replicated serverside in the remote
   // config. Specifying them overrides remote (local takes precendence).
@@ -21,7 +21,7 @@ export type PartialConfig = PartialDeep<Config> & { earnerID: string };
 
 export const DefaultAPIBaseURL = "https://api.getmash.com";
 export const DefaultWalletURL = "https://wallet.getmash.com/widget";
-export const DefaultModalURL = "https://wallet.getmash.com/modal";
+export const DefaultPreboardingURL = "https://wallet.getmash.com/preboarding";
 export const DefaultWidgetBaseURL = "https://widgets.getmash.com";
 
 const DEFAULT_WIDGETS_CONFIG: WidgetConfig = {
@@ -35,7 +35,7 @@ export default function parse(config: PartialConfig): Config {
     earnerID: config.earnerID,
     api: config.api || DefaultAPIBaseURL,
     walletURL: config.walletURL || DefaultWalletURL,
-    modalURL: config.modalURL || DefaultModalURL,
+    preboardingURL: config.preboardingURL || DefaultPreboardingURL,
     widgets: { ...DEFAULT_WIDGETS_CONFIG, ...config.widgets },
     autoHide: config.autoHide,
   };

--- a/packages/client-sdk/src/config.ts
+++ b/packages/client-sdk/src/config.ts
@@ -10,6 +10,7 @@ export type Config = {
   api: string;
   earnerID: string;
   walletURL: string;
+  modalURL: string;
   widgets: WidgetConfig;
   // Local properties that are replicated serverside in the remote
   // config. Specifying them overrides remote (local takes precendence).
@@ -20,6 +21,7 @@ export type PartialConfig = PartialDeep<Config> & { earnerID: string };
 
 export const DefaultAPIBaseURL = "https://api.getmash.com";
 export const DefaultWalletURL = "https://wallet.getmash.com/widget";
+export const DefaultModalURL = "https://wallet.getmash.com/modal";
 export const DefaultWidgetBaseURL = "https://widgets.getmash.com";
 
 const DEFAULT_WIDGETS_CONFIG: WidgetConfig = {
@@ -33,6 +35,7 @@ export default function parse(config: PartialConfig): Config {
     earnerID: config.earnerID,
     api: config.api || DefaultAPIBaseURL,
     walletURL: config.walletURL || DefaultWalletURL,
+    modalURL: config.modalURL || DefaultModalURL,
     widgets: { ...DEFAULT_WIDGETS_CONFIG, ...config.widgets },
     autoHide: config.autoHide,
   };

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, it } from "node:test";
 
 import { waitFor } from "@testing-library/dom";
 
-
 import PostMessageEngine from "@getmash/post-message";
 
 import {

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -12,11 +12,7 @@ import {
 } from "../api/routes.js";
 import { createDOM } from "../tests/dom.js";
 import IFrame, {
-  Targets,
-  EventMessage,
-  Events,
   IFRAME_NAME,
-  toHTMLStyle,
   MAX_CONTENT_HEIGHT,
   MAX_CONTENT_WIDTH,
   MIN_CONTENT_HEIGHT,
@@ -29,6 +25,7 @@ import IFrame, {
   INTERCOM_SHIFT,
 } from "./IFrame.js";
 import { getWalletPosition } from "./position.js";
+import { EventMessage, Events, Targets, toHTMLStyle } from "./blocks.js";
 
 const WALLET_IFRAME_URL = "http://localhost/widget";
 

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -30,7 +30,8 @@ import IFrame, {
 } from "./IFrame.js";
 import { getWalletPosition } from "./position.js";
 
-const IFRAME_SOURCE = "http://localhost";
+const WALLET_IFRAME_URL = "http://localhost/widget";
+const MODAL_IFRAME_URL = "http://localhost/modal";
 
 const MASH_SETTINGS: { id: string; position: Partial<WalletButtonPosition> } = {
   id: "123",
@@ -46,7 +47,7 @@ const replacePostMessage = (sourceWindow: Window | null) => {
     window.dispatchEvent(
       new window.MessageEvent("message", {
         source: sourceWindow,
-        origin: IFRAME_SOURCE,
+        origin: new URL(WALLET_IFRAME_URL).origin,
         data: message,
       }),
     );
@@ -82,7 +83,7 @@ describe("IFrame Events", () => {
   it("mount iframe, should exist in dom", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -97,7 +98,7 @@ describe("IFrame Events", () => {
   it("trigger open event, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -136,7 +137,7 @@ describe("IFrame Events", () => {
   it("trigger close event, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -174,7 +175,7 @@ describe("IFrame Events", () => {
   it("trigger 2 notifications, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -215,7 +216,7 @@ describe("IFrame Desktop", () => {
   it("desktop, position iframe on left, should have valid css settigns", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -243,7 +244,7 @@ describe("IFrame Desktop", () => {
   it("desktop, position iframe on right, should have valid css settigns", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -271,7 +272,7 @@ describe("IFrame Desktop", () => {
   it("bottom-right, horizontal shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -297,7 +298,7 @@ describe("IFrame Desktop", () => {
   it("bottom-left, horizontal shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -323,7 +324,7 @@ describe("IFrame Desktop", () => {
   it("bottom-right, horizontal shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -352,7 +353,7 @@ describe("IFrame Desktop", () => {
   it("bottom-left, horizontal shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -381,7 +382,7 @@ describe("IFrame Desktop", () => {
   it("vertical shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -407,7 +408,7 @@ describe("IFrame Desktop", () => {
   it("vertical shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -436,7 +437,7 @@ describe("IFrame Desktop", () => {
   it("basic horizontal shift to the left", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -465,7 +466,7 @@ describe("IFrame Desktop", () => {
   it("basic horizontal shift to the right", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -494,7 +495,7 @@ describe("IFrame Desktop", () => {
   it("basic vertical shift up", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -523,7 +524,7 @@ describe("IFrame Desktop", () => {
   it("using Ghost shift, right side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -550,7 +551,7 @@ describe("IFrame Desktop", () => {
   it("using Intercom shift, right side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -579,7 +580,7 @@ describe("IFrame Desktop", () => {
   it("using Ghost shift, left side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -606,7 +607,7 @@ describe("IFrame Desktop", () => {
   it("using Intercom shift, left side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -636,7 +637,7 @@ describe("IFrame Desktop", () => {
   it("using custom shift", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -669,7 +670,7 @@ describe("IFrame Mobile", () => {
   it("mobile, position iframe on left, should have valid css settigns", async () => {
     mockMatchMedia(true);
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -697,7 +698,7 @@ describe("IFrame Mobile", () => {
   it("mobile, position iframe on right, should have valid css settigns", async () => {
     mockMatchMedia(true);
 
-    const iframe = new IFrame(IFRAME_SOURCE);
+    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -27,7 +27,7 @@ import IFrame, {
 import { getWalletPosition } from "./position.js";
 import { EventMessage, Events, Targets, toHTMLStyle } from "./blocks.js";
 
-const WALLET_IFRAME_URL = "http://localhost/widget";
+const IFRAME_SOURCE = "http://localhost/widget";
 
 const MASH_SETTINGS: { id: string; position: Partial<WalletButtonPosition> } = {
   id: "123",
@@ -43,7 +43,7 @@ const replacePostMessage = (sourceWindow: Window | null) => {
     window.dispatchEvent(
       new window.MessageEvent("message", {
         source: sourceWindow,
-        origin: new URL(WALLET_IFRAME_URL).origin,
+        origin: new URL(IFRAME_SOURCE).origin,
         data: message,
       }),
     );
@@ -79,7 +79,7 @@ describe("IFrame Events", () => {
   it("mount iframe, should exist in dom", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -94,7 +94,7 @@ describe("IFrame Events", () => {
   it("trigger open event, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -133,7 +133,7 @@ describe("IFrame Events", () => {
   it("trigger close event, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -171,7 +171,7 @@ describe("IFrame Events", () => {
   it("trigger 2 notifications, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -212,7 +212,7 @@ describe("IFrame Desktop", () => {
   it("desktop, position iframe on left, should have valid css settigns", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -240,7 +240,7 @@ describe("IFrame Desktop", () => {
   it("desktop, position iframe on right, should have valid css settigns", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -268,7 +268,7 @@ describe("IFrame Desktop", () => {
   it("bottom-right, horizontal shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -294,7 +294,7 @@ describe("IFrame Desktop", () => {
   it("bottom-left, horizontal shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -320,7 +320,7 @@ describe("IFrame Desktop", () => {
   it("bottom-right, horizontal shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -349,7 +349,7 @@ describe("IFrame Desktop", () => {
   it("bottom-left, horizontal shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -378,7 +378,7 @@ describe("IFrame Desktop", () => {
   it("vertical shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -404,7 +404,7 @@ describe("IFrame Desktop", () => {
   it("vertical shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -433,7 +433,7 @@ describe("IFrame Desktop", () => {
   it("basic horizontal shift to the left", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -462,7 +462,7 @@ describe("IFrame Desktop", () => {
   it("basic horizontal shift to the right", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -491,7 +491,7 @@ describe("IFrame Desktop", () => {
   it("basic vertical shift up", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -520,7 +520,7 @@ describe("IFrame Desktop", () => {
   it("using Ghost shift, right side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -547,7 +547,7 @@ describe("IFrame Desktop", () => {
   it("using Intercom shift, right side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -576,7 +576,7 @@ describe("IFrame Desktop", () => {
   it("using Ghost shift, left side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -603,7 +603,7 @@ describe("IFrame Desktop", () => {
   it("using Intercom shift, left side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -633,7 +633,7 @@ describe("IFrame Desktop", () => {
   it("using custom shift", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -666,7 +666,7 @@ describe("IFrame Mobile", () => {
   it("mobile, position iframe on left, should have valid css settigns", async () => {
     mockMatchMedia(true);
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -694,7 +694,7 @@ describe("IFrame Mobile", () => {
   it("mobile, position iframe on right, should have valid css settigns", async () => {
     mockMatchMedia(true);
 
-    const iframe = new IFrame(WALLET_IFRAME_URL);
+    const iframe = new IFrame(IFRAME_SOURCE);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, it } from "node:test";
 
 import { waitFor } from "@testing-library/dom";
 
+
 import PostMessageEngine from "@getmash/post-message";
 
 import {
@@ -24,8 +25,8 @@ import IFrame, {
   GHOST_SHIFT,
   INTERCOM_SHIFT,
 } from "./IFrame.js";
-import { getWalletPosition } from "./position.js";
 import { EventMessage, Events, Targets, toHTMLStyle } from "./blocks.js";
+import { getWalletPosition } from "./position.js";
 
 const IFRAME_SOURCE = "http://localhost/widget";
 

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -31,7 +31,6 @@ import IFrame, {
 import { getWalletPosition } from "./position.js";
 
 const WALLET_IFRAME_URL = "http://localhost/widget";
-const MODAL_IFRAME_URL = "http://localhost/modal";
 
 const MASH_SETTINGS: { id: string; position: Partial<WalletButtonPosition> } = {
   id: "123",
@@ -83,7 +82,7 @@ describe("IFrame Events", () => {
   it("mount iframe, should exist in dom", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -98,7 +97,7 @@ describe("IFrame Events", () => {
   it("trigger open event, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -108,7 +107,7 @@ describe("IFrame Events", () => {
     );
 
     // @ts-expect-error grabbing the private iframe to get window
-    replacePostMessage(iframe.walletIframe.contentWindow);
+    replacePostMessage(iframe.iframe.contentWindow);
 
     // pretend to be the app in the iframe asking the SDK to resize it
     const wallet = new PostMessageEngine<EventMessage>({
@@ -137,7 +136,7 @@ describe("IFrame Events", () => {
   it("trigger close event, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -147,7 +146,7 @@ describe("IFrame Events", () => {
     );
 
     // @ts-expect-error grabbing the private iframe to get window
-    replacePostMessage(iframe.walletIframe.contentWindow);
+    replacePostMessage(iframe.iframe.contentWindow);
 
     // pretend to be the app in the iframe asking the SDK to resize it
     const wallet = new PostMessageEngine<EventMessage>({
@@ -175,7 +174,7 @@ describe("IFrame Events", () => {
   it("trigger 2 notifications, should resize iframe correctly", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(
       () => ({}),
       getWalletPosition(
@@ -185,7 +184,7 @@ describe("IFrame Events", () => {
     );
 
     // @ts-expect-error grabbing the private iframe to get window
-    replacePostMessage(iframe.walletIframe.contentWindow);
+    replacePostMessage(iframe.iframe.contentWindow);
 
     // pretend to be the app in the iframe asking the SDK to resize it
     const wallet = new PostMessageEngine<EventMessage>({
@@ -216,7 +215,7 @@ describe("IFrame Desktop", () => {
   it("desktop, position iframe on left, should have valid css settigns", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -244,7 +243,7 @@ describe("IFrame Desktop", () => {
   it("desktop, position iframe on right, should have valid css settigns", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -272,7 +271,7 @@ describe("IFrame Desktop", () => {
   it("bottom-right, horizontal shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -298,7 +297,7 @@ describe("IFrame Desktop", () => {
   it("bottom-left, horizontal shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -324,7 +323,7 @@ describe("IFrame Desktop", () => {
   it("bottom-right, horizontal shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -353,7 +352,7 @@ describe("IFrame Desktop", () => {
   it("bottom-left, horizontal shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -382,7 +381,7 @@ describe("IFrame Desktop", () => {
   it("vertical shift is less than 0, should normalize to 0", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -408,7 +407,7 @@ describe("IFrame Desktop", () => {
   it("vertical shift is greater than max, should normalize to max", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -437,7 +436,7 @@ describe("IFrame Desktop", () => {
   it("basic horizontal shift to the left", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -466,7 +465,7 @@ describe("IFrame Desktop", () => {
   it("basic horizontal shift to the right", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -495,7 +494,7 @@ describe("IFrame Desktop", () => {
   it("basic vertical shift up", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -524,7 +523,7 @@ describe("IFrame Desktop", () => {
   it("using Ghost shift, right side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -551,7 +550,7 @@ describe("IFrame Desktop", () => {
   it("using Intercom shift, right side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -580,7 +579,7 @@ describe("IFrame Desktop", () => {
   it("using Ghost shift, left side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -607,7 +606,7 @@ describe("IFrame Desktop", () => {
   it("using Intercom shift, left side", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Left,
@@ -637,7 +636,7 @@ describe("IFrame Desktop", () => {
   it("using custom shift", async () => {
     mockMatchMedia();
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -670,7 +669,7 @@ describe("IFrame Mobile", () => {
   it("mobile, position iframe on left, should have valid css settigns", async () => {
     mockMatchMedia(true);
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,
@@ -698,7 +697,7 @@ describe("IFrame Mobile", () => {
   it("mobile, position iframe on right, should have valid css settigns", async () => {
     mockMatchMedia(true);
 
-    const iframe = new IFrame(WALLET_IFRAME_URL, MODAL_IFRAME_URL);
+    const iframe = new IFrame(WALLET_IFRAME_URL);
     iframe.mount(() => ({}), {
       desktop: {
         floatSide: WalletButtonFloatSide.Right,

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -108,7 +108,7 @@ describe("IFrame Events", () => {
     );
 
     // @ts-expect-error grabbing the private iframe to get window
-    replacePostMessage(iframe.iframe.contentWindow);
+    replacePostMessage(iframe.walletIframe.contentWindow);
 
     // pretend to be the app in the iframe asking the SDK to resize it
     const wallet = new PostMessageEngine<EventMessage>({
@@ -147,7 +147,7 @@ describe("IFrame Events", () => {
     );
 
     // @ts-expect-error grabbing the private iframe to get window
-    replacePostMessage(iframe.iframe.contentWindow);
+    replacePostMessage(iframe.walletIframe.contentWindow);
 
     // pretend to be the app in the iframe asking the SDK to resize it
     const wallet = new PostMessageEngine<EventMessage>({
@@ -185,7 +185,7 @@ describe("IFrame Events", () => {
     );
 
     // @ts-expect-error grabbing the private iframe to get window
-    replacePostMessage(iframe.iframe.contentWindow);
+    replacePostMessage(iframe.walletIframe.contentWindow);
 
     // pretend to be the app in the iframe asking the SDK to resize it
     const wallet = new PostMessageEngine<EventMessage>({

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -6,7 +6,14 @@ import {
   WalletButtonPosition,
   WalletButtonShiftConfiguration,
 } from "../api/routes.js";
-import { EventMessage, Events, MAX_Z_INDEX, OnLoadCallback, Targets, toHTMLStyle } from "./blocks.js";
+import {
+  EventMessage,
+  Events,
+  MAX_Z_INDEX,
+  OnLoadCallback,
+  Targets,
+  toHTMLStyle,
+} from "./blocks.js";
 
 enum Layout {
   Web = "web",

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -71,7 +71,7 @@ const MODAL_CONTAINER_STYLE = {
   left: "0",
   "z-index": MAX_Z_INDEX,
   visibility: "hidden",
-}
+};
 
 const IFRAME_STYLE = {
   border: "none",
@@ -152,7 +152,10 @@ export default class IFrame {
     // Create wallet dom elements
     this.walletContainer = document.createElement("div");
     this.walletContainer.setAttribute("class", "mash mash-root");
-    this.walletContainer.setAttribute("style", toHTMLStyle(WALLET_CONTAINER_STYLE));
+    this.walletContainer.setAttribute(
+      "style",
+      toHTMLStyle(WALLET_CONTAINER_STYLE),
+    );
 
     this.walletIframe = document.createElement("iframe");
     this.walletIframe.setAttribute("class", "mash-this.iframe");
@@ -164,7 +167,10 @@ export default class IFrame {
 
     // Create modal dom elements
     this.modalContainer = document.createElement("div");
-    this.modalContainer.setAttribute("style", toHTMLStyle(MODAL_CONTAINER_STYLE));
+    this.modalContainer.setAttribute(
+      "style",
+      toHTMLStyle(MODAL_CONTAINER_STYLE),
+    );
 
     this.modalIframe = document.createElement("iframe");
     this.modalIframe.setAttribute("title", "Mash Pre-Boarding");
@@ -205,14 +211,14 @@ export default class IFrame {
    */
   private showModal = () => {
     this.modalContainer.style.visibility = "visible";
-  }
+  };
 
   /**
    * Close full screen modal
    */
   private hideModal = () => {
     this.modalContainer.style.visibility = "hidden";
-  }
+  };
 
   /**
    * Resize the iframe container based on open state, notification count and
@@ -506,7 +512,7 @@ export default class IFrame {
       MAX_SHIFT_VERTICAL,
     );
     this.mobileFloatSide = position.mobile.floatSide;
-    this.mobileFloatPlacement = position.mobile.floatPlacement;    
+    this.mobileFloatPlacement = position.mobile.floatPlacement;
     this.mobileShiftConfiguration.vertical = this.normalizeShift(
       position.mobile.customShiftConfiguration?.vertical || 0,
       MAX_SHIFT_VERTICAL,

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -89,8 +89,8 @@ const WALLET_IFRAME_STYLE = {
 const MODAL_IFRAME_STYLE = {
   border: "none",
   "border-radius": "20px",
-  width: "70%",
-  height: "70%",
+  width: "1000px",
+  height: "665px",
   "background-color": "inherit !important",
   "color-scheme": "normal",
 };

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -406,9 +406,6 @@ export default class IFrame {
    */
   private setupListeners() {
     this.getMediaQuery().addEventListener("change", this.onMediaQueryChanged);
-
-    // Clicking on the modal backdrop closes the modal
-    this.modalContainer.onclick = this.hideModal;
   }
 
   /**

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -46,7 +46,7 @@ export const WIX_ACTION_BAR = 74;
 
 const MAX_Z_INDEX = 2147483647;
 
-const WALLET_CONTAINER_STYLE = {
+const CONTAINER_STYLE = {
   position: "fixed",
   bottom: "0",
   right: "0",
@@ -60,17 +60,6 @@ const WALLET_CONTAINER_STYLE = {
   animation: "none !important",
   "background-color": "transparent !important",
   transition: "none !important",
-};
-
-const MODAL_CONTAINER_STYLE = {
-  border: "none",
-  width: "100%",
-  height: "100vh",
-  position: "fixed",
-  top: "0",
-  left: "0",
-  "z-index": MAX_Z_INDEX,
-  visibility: "hidden",
 };
 
 const IFRAME_STYLE = {
@@ -140,44 +129,25 @@ export default class IFrame {
     vertical: 0,
   };
 
-  private walletContainer: HTMLDivElement;
-  private walletIframe: HTMLIFrameElement;
-  private modalContainer: HTMLDivElement;
-  private modalIframe: HTMLIFrameElement;
+  private container: HTMLDivElement;
+  private iframe: HTMLIFrameElement;
   private engine: PostMessageEngine<EventMessage> | null = null;
 
-  constructor(walletSrc: string, modalSrc: string) {
+  constructor(walletSrc: string) {
     this.src = new URL(walletSrc);
 
     // Create wallet dom elements
-    this.walletContainer = document.createElement("div");
-    this.walletContainer.setAttribute("class", "mash mash-root");
-    this.walletContainer.setAttribute(
-      "style",
-      toHTMLStyle(WALLET_CONTAINER_STYLE),
-    );
+    this.container = document.createElement("div");
+    this.container.setAttribute("class", "mash mash-root");
+    this.container.setAttribute("style", toHTMLStyle(CONTAINER_STYLE));
 
-    this.walletIframe = document.createElement("iframe");
-    this.walletIframe.setAttribute("class", "mash-this.iframe");
-    this.walletIframe.setAttribute("style", toHTMLStyle(IFRAME_STYLE));
-    this.walletIframe.setAttribute("src", walletSrc);
-    this.walletIframe.setAttribute("title", "Mash Wallet");
-    this.walletIframe.setAttribute("name", IFRAME_NAME);
-    this.walletIframe.allowFullscreen = true;
-
-    // Create modal dom elements
-    this.modalContainer = document.createElement("div");
-    this.modalContainer.setAttribute(
-      "style",
-      toHTMLStyle(MODAL_CONTAINER_STYLE),
-    );
-
-    this.modalIframe = document.createElement("iframe");
-    this.modalIframe.setAttribute("title", "Mash Pre-Boarding");
-    this.modalIframe.setAttribute("style", toHTMLStyle(IFRAME_STYLE));
-    this.modalIframe.setAttribute("name", MODAL_IFRAME_NAME);
-    this.modalIframe.setAttribute("src", modalSrc);
-    this.modalIframe.allowFullscreen = true;
+    this.iframe = document.createElement("iframe");
+    this.iframe.setAttribute("class", "mash-this.iframe");
+    this.iframe.setAttribute("style", toHTMLStyle(IFRAME_STYLE));
+    this.iframe.setAttribute("src", walletSrc);
+    this.iframe.setAttribute("title", "Mash Wallet");
+    this.iframe.setAttribute("name", IFRAME_NAME);
+    this.iframe.allowFullscreen = true;
   }
 
   /**
@@ -192,32 +162,18 @@ export default class IFrame {
     unit: "%" | "px",
     margin: boolean,
   ) => {
-    this.walletContainer.style.height = `${height}${unit}`;
-    this.walletContainer.style.width = `${width}${unit}`;
+    this.container.style.height = `${height}${unit}`;
+    this.container.style.width = `${width}${unit}`;
 
     if (margin) {
-      this.walletContainer.style.marginRight = "20px";
-      this.walletContainer.style.marginLeft = "20px";
-      this.walletContainer.style.marginBottom = "20px";
+      this.container.style.marginRight = "20px";
+      this.container.style.marginLeft = "20px";
+      this.container.style.marginBottom = "20px";
     } else {
-      this.walletContainer.style.marginRight = "0";
-      this.walletContainer.style.marginLeft = "0";
-      this.walletContainer.style.marginBottom = "0";
+      this.container.style.marginRight = "0";
+      this.container.style.marginLeft = "0";
+      this.container.style.marginBottom = "0";
     }
-  };
-
-  /**
-   * Show full screen modal
-   */
-  private showModal = () => {
-    this.modalContainer.style.visibility = "visible";
-  };
-
-  /**
-   * Close full screen modal
-   */
-  private hideModal = () => {
-    this.modalContainer.style.visibility = "hidden";
   };
 
   /**
@@ -269,31 +225,31 @@ export default class IFrame {
 
     // Mobile
     if (mediaQuery.matches) {
-      this.walletContainer.style.bottom = "0";
+      this.container.style.bottom = "0";
 
       switch (this.mobileFloatSide) {
         case WalletButtonFloatSide.Left: {
-          this.walletContainer.style.right = "";
-          this.walletContainer.style.left = "0";
+          this.container.style.right = "";
+          this.container.style.left = "0";
           break;
         }
         case WalletButtonFloatSide.Right: {
-          this.walletContainer.style.right = "0";
-          this.walletContainer.style.left = "";
+          this.container.style.right = "0";
+          this.container.style.left = "";
           break;
         }
       }
       switch (this.mobileFloatPlacement) {
         case WalletButtonFloatPlacement.WixActionBar: {
-          this.walletContainer.style.bottom = `${WIX_ACTION_BAR}px`;
+          this.container.style.bottom = `${WIX_ACTION_BAR}px`;
           break;
         }
         case WalletButtonFloatPlacement.BasicShiftVertical: {
-          this.walletContainer.style.bottom = `${BASIC_SHIFT_VERTICAL}px`;
+          this.container.style.bottom = `${BASIC_SHIFT_VERTICAL}px`;
           break;
         }
         case WalletButtonFloatPlacement.Custom: {
-          this.walletContainer.style.bottom = `${this.mobileShiftConfiguration.vertical}px`;
+          this.container.style.bottom = `${this.mobileShiftConfiguration.vertical}px`;
           break;
         }
       }
@@ -303,13 +259,13 @@ export default class IFrame {
     // Desktop
     switch (this.desktopFloatSide) {
       case WalletButtonFloatSide.Left: {
-        this.walletContainer.style.left = "0";
-        this.walletContainer.style.right = "";
+        this.container.style.left = "0";
+        this.container.style.right = "";
         break;
       }
       case WalletButtonFloatSide.Right: {
-        this.walletContainer.style.right = "0";
-        this.walletContainer.style.left = "";
+        this.container.style.right = "0";
+        this.container.style.left = "";
         break;
       }
     }
@@ -317,68 +273,68 @@ export default class IFrame {
       case WalletButtonFloatPlacement.Ghost: {
         switch (this.desktopFloatSide) {
           case WalletButtonFloatSide.Left: {
-            this.walletContainer.style.left = "0";
-            this.walletContainer.style.right = "";
+            this.container.style.left = "0";
+            this.container.style.right = "";
             break;
           }
           case WalletButtonFloatSide.Right: {
-            this.walletContainer.style.right = "0";
-            this.walletContainer.style.left = "";
+            this.container.style.right = "0";
+            this.container.style.left = "";
             break;
           }
         }
-        this.walletContainer.style.bottom = `${GHOST_SHIFT}px`;
+        this.container.style.bottom = `${GHOST_SHIFT}px`;
         break;
       }
       case WalletButtonFloatPlacement.Intercom: {
         switch (this.desktopFloatSide) {
           case WalletButtonFloatSide.Left: {
-            this.walletContainer.style.left = "0";
-            this.walletContainer.style.right = "";
+            this.container.style.left = "0";
+            this.container.style.right = "";
             break;
           }
           case WalletButtonFloatSide.Right: {
-            this.walletContainer.style.right = "0";
-            this.walletContainer.style.left = "";
+            this.container.style.right = "0";
+            this.container.style.left = "";
             break;
           }
         }
-        this.walletContainer.style.bottom = `${INTERCOM_SHIFT}px`;
+        this.container.style.bottom = `${INTERCOM_SHIFT}px`;
         break;
       }
       case WalletButtonFloatPlacement.BasicShiftHorizontal: {
         switch (this.desktopFloatSide) {
           case WalletButtonFloatSide.Left: {
-            this.walletContainer.style.left = `${BASIC_SHIFT_HORIZONTAL}px`;
-            this.walletContainer.style.right = "";
+            this.container.style.left = `${BASIC_SHIFT_HORIZONTAL}px`;
+            this.container.style.right = "";
             break;
           }
           case WalletButtonFloatSide.Right: {
-            this.walletContainer.style.right = `${BASIC_SHIFT_HORIZONTAL}px`;
-            this.walletContainer.style.left = "";
+            this.container.style.right = `${BASIC_SHIFT_HORIZONTAL}px`;
+            this.container.style.left = "";
             break;
           }
         }
         break;
       }
       case WalletButtonFloatPlacement.BasicShiftVertical: {
-        this.walletContainer.style.bottom = `${BASIC_SHIFT_VERTICAL}px`;
+        this.container.style.bottom = `${BASIC_SHIFT_VERTICAL}px`;
         break;
       }
       case WalletButtonFloatPlacement.Custom: {
         switch (this.desktopFloatSide) {
           case WalletButtonFloatSide.Left: {
-            this.walletContainer.style.left = `${this.desktopShiftConfiguration.horizontal}px`;
-            this.walletContainer.style.right = "";
+            this.container.style.left = `${this.desktopShiftConfiguration.horizontal}px`;
+            this.container.style.right = "";
             break;
           }
           case WalletButtonFloatSide.Right: {
-            this.walletContainer.style.right = `${this.desktopShiftConfiguration.horizontal}px`;
-            this.walletContainer.style.left = "";
+            this.container.style.right = `${this.desktopShiftConfiguration.horizontal}px`;
+            this.container.style.left = "";
             break;
           }
         }
-        this.walletContainer.style.bottom = `${this.desktopShiftConfiguration.vertical}px`;
+        this.container.style.bottom = `${this.desktopShiftConfiguration.vertical}px`;
         break;
       }
     }
@@ -443,16 +399,6 @@ export default class IFrame {
       if (!data) return;
 
       switch (data.name) {
-        case Events.ModalOpen: {
-          this.open = false;
-          this.showModal();
-          break;
-        }
-        case Events.ModalClose: {
-          this.open = false;
-          this.hideModal();
-          break;
-        }
         case Events.WalletOpened: {
           this.open = true;
           this.resize();
@@ -477,7 +423,7 @@ export default class IFrame {
             metadata: { mode: mq.matches ? Layout.Mobile : Layout.Web },
           });
 
-          onLoadCallback(this.walletIframe);
+          onLoadCallback(this.iframe);
           break;
         }
       }
@@ -491,11 +437,8 @@ export default class IFrame {
    */
   mount(onLoad: OnLoadCallback, position: WalletButtonPosition) {
     if (!this.mounted) {
-      this.walletContainer.appendChild(this.walletIframe);
-      document.body.appendChild(this.walletContainer);
-
-      this.modalContainer.appendChild(this.modalIframe);
-      document.body.appendChild(this.modalContainer);
+      this.container.appendChild(this.iframe);
+      document.body.appendChild(this.container);
 
       this.mounted = true;
     }
@@ -524,9 +467,8 @@ export default class IFrame {
     this.engine = new PostMessageEngine({
       name: Targets.HostSiteFrame,
       targetName: Targets.Wallet,
-      targetWindow: this.walletIframe.contentWindow,
+      targetWindow: this.iframe.contentWindow,
       targetOrigin: this.src.origin,
-      targetWindowFilter: false,
     });
 
     this.setupListeners();

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -160,8 +160,8 @@ export default class IFrame {
   private modalIframe: HTMLIFrameElement;
   private engine: PostMessageEngine<EventMessage> | null = null;
 
-  constructor(src: string) {
-    this.src = new URL(src);
+  constructor(walletSrc: string, modalSrc: string) {
+    this.src = new URL(walletSrc);
 
     // Create wallet dom elements
     this.walletContainer = document.createElement("div");
@@ -171,7 +171,7 @@ export default class IFrame {
     this.walletIframe = document.createElement("iframe");
     this.walletIframe.setAttribute("class", "mash-this.iframe");
     this.walletIframe.setAttribute("style", toHTMLStyle(WALLET_IFRAME_STYLE));
-    this.walletIframe.setAttribute("src", src);
+    this.walletIframe.setAttribute("src", walletSrc);
     this.walletIframe.setAttribute("title", "Mash Wallet");
     this.walletIframe.setAttribute("name", IFRAME_NAME);
     this.walletIframe.allowFullscreen = true;
@@ -184,7 +184,7 @@ export default class IFrame {
     this.modalIframe.setAttribute("title", "Mash Pre-Boarding");
     this.modalIframe.setAttribute("style", toHTMLStyle(MODAL_IFRAME_STYLE));
     this.modalIframe.setAttribute("name", MODAL_IFRAME_NAME);
-    this.modalIframe.setAttribute("src", "https://wallet.getmash.com/earn");
+    this.modalIframe.setAttribute("src", modalSrc);
     this.modalIframe.allowFullscreen = true;
   }
 

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -64,33 +64,19 @@ const WALLET_CONTAINER_STYLE = {
 
 const MODAL_CONTAINER_STYLE = {
   border: "none",
-  width: "100vw",
+  width: "100%",
   height: "100vh",
   position: "fixed",
   top: "0",
   left: "0",
   "z-index": MAX_Z_INDEX,
-  "backdrop-filter": "blur(7.5px)",
   visibility: "hidden",
-  display: "flex",
-  "flex-direction": "column",
-  "align-items": "center",
-  "justify-content": "center",
 }
 
-const WALLET_IFRAME_STYLE = {
+const IFRAME_STYLE = {
   border: "none",
   width: "100%",
   height: "100%",
-  "background-color": "inherit !important",
-  "color-scheme": "normal",
-};
-
-const MODAL_IFRAME_STYLE = {
-  border: "none",
-  "border-radius": "20px",
-  width: "1000px",
-  height: "665px",
   "background-color": "inherit !important",
   "color-scheme": "normal",
 };
@@ -170,7 +156,7 @@ export default class IFrame {
 
     this.walletIframe = document.createElement("iframe");
     this.walletIframe.setAttribute("class", "mash-this.iframe");
-    this.walletIframe.setAttribute("style", toHTMLStyle(WALLET_IFRAME_STYLE));
+    this.walletIframe.setAttribute("style", toHTMLStyle(IFRAME_STYLE));
     this.walletIframe.setAttribute("src", walletSrc);
     this.walletIframe.setAttribute("title", "Mash Wallet");
     this.walletIframe.setAttribute("name", IFRAME_NAME);
@@ -182,7 +168,7 @@ export default class IFrame {
 
     this.modalIframe = document.createElement("iframe");
     this.modalIframe.setAttribute("title", "Mash Pre-Boarding");
-    this.modalIframe.setAttribute("style", toHTMLStyle(MODAL_IFRAME_STYLE));
+    this.modalIframe.setAttribute("style", toHTMLStyle(IFRAME_STYLE));
     this.modalIframe.setAttribute("name", MODAL_IFRAME_NAME);
     this.modalIframe.setAttribute("src", modalSrc);
     this.modalIframe.allowFullscreen = true;
@@ -537,6 +523,7 @@ export default class IFrame {
       targetName: Targets.Wallet,
       targetWindow: this.walletIframe.contentWindow,
       targetOrigin: this.src.origin,
+      targetWindowFilter: false,
     });
 
     this.setupListeners();

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -72,7 +72,6 @@ const IFRAME_STYLE = {
 };
 
 export const IFRAME_NAME = "mash_wallet";
-export const MODAL_IFRAME_NAME = "mash_modal";
 
 export default class IFrame {
   readonly src: URL;
@@ -105,8 +104,8 @@ export default class IFrame {
   private iframe: HTMLIFrameElement;
   private engine: PostMessageEngine<EventMessage> | null = null;
 
-  constructor(walletSrc: string) {
-    this.src = new URL(walletSrc);
+  constructor(src: string) {
+    this.src = new URL(src);
 
     // Create wallet dom elements
     this.container = document.createElement("div");
@@ -116,7 +115,7 @@ export default class IFrame {
     this.iframe = document.createElement("iframe");
     this.iframe.setAttribute("class", "mash-this.iframe");
     this.iframe.setAttribute("style", toHTMLStyle(IFRAME_STYLE));
-    this.iframe.setAttribute("src", walletSrc);
+    this.iframe.setAttribute("src", src);
     this.iframe.setAttribute("title", "Mash Wallet");
     this.iframe.setAttribute("name", IFRAME_NAME);
     this.iframe.allowFullscreen = true;
@@ -411,11 +410,9 @@ export default class IFrame {
     if (!this.mounted) {
       this.container.appendChild(this.iframe);
       document.body.appendChild(this.container);
-
       this.mounted = true;
     }
 
-    // Wallet settings
     this.desktopFloatSide = position.desktop.floatSide;
     this.desktopFloatPlacement = position.desktop.floatPlacement;
     this.desktopShiftConfiguration.horizontal = this.normalizeShift(

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -6,11 +6,7 @@ import {
   WalletButtonPosition,
   WalletButtonShiftConfiguration,
 } from "../api/routes.js";
-
-export enum Targets {
-  HostSiteFrame = "@mash/host-site-iframe",
-  Wallet = "@mash/wallet",
-}
+import { EventMessage, Events, MAX_Z_INDEX, OnLoadCallback, Targets, toHTMLStyle } from "./blocks.js";
 
 enum Layout {
   Web = "web",
@@ -44,8 +40,6 @@ export const INTERCOM_SHIFT = 60;
 /* Amount used to shift for Wix Action Bar */
 export const WIX_ACTION_BAR = 74;
 
-const MAX_Z_INDEX = 2147483647;
-
 const CONTAINER_STYLE = {
   position: "fixed",
   bottom: "0",
@@ -69,35 +63,6 @@ const IFRAME_STYLE = {
   "background-color": "inherit !important",
   "color-scheme": "normal",
 };
-
-export type EventMessage<T = Record<string, unknown>> = {
-  name: string;
-  metadata: T;
-};
-
-export type OnLoadCallback = (iframe: HTMLIFrameElement) => void;
-
-/**
- * Converts a dict of styles into HTML acceptable style string
- * @param styles Record<string, string|number>
- * @returns string
- */
-export function toHTMLStyle(styles: Record<string, string | number>): string {
-  return Object.keys(styles).reduce((str, key) => {
-    const style = styles[key];
-    return (str += `${key}:${style};`);
-  }, "");
-}
-
-export enum Events {
-  ModalOpen = "modal:open",
-  ModalClose = "modal:close",
-  WalletOpened = "wallet:open",
-  WalletClosed = "wallet:close",
-  WalletLoaded = "wallet:loaded",
-  LayoutChanged = "layout:changed",
-  NotificationUpdate = "notifications:update",
-}
 
 export const IFRAME_NAME = "mash_wallet";
 export const MODAL_IFRAME_NAME = "mash_modal";

--- a/packages/client-sdk/src/iframe/ModalIFrame.ts
+++ b/packages/client-sdk/src/iframe/ModalIFrame.ts
@@ -1,4 +1,5 @@
 import PostMessageEngine from "@getmash/post-message";
+
 import {
   EventMessage,
   Events,

--- a/packages/client-sdk/src/iframe/ModalIFrame.ts
+++ b/packages/client-sdk/src/iframe/ModalIFrame.ts
@@ -1,0 +1,154 @@
+import PostMessageEngine from "@getmash/post-message";
+
+const MAX_Z_INDEX = 2147483647;
+
+const CONTAINER_STYLE = {
+  border: "none",
+  width: "100%",
+  height: "100vh",
+  position: "fixed",
+  top: "0",
+  left: "0",
+  "z-index": MAX_Z_INDEX,
+  visibility: "hidden",
+};
+
+const IFRAME_STYLE = {
+  border: "none",
+  width: "100%",
+  height: "100%",
+  "background-color": "inherit !important",
+  "color-scheme": "normal",
+};
+
+export enum Targets {
+  HostSiteFrame = "@mash/host-site-iframe",
+  Modal = "@mash/modal",
+}
+
+export type EventMessage<T = Record<string, unknown>> = {
+  name: string;
+  metadata: T;
+};
+
+export type OnLoadCallback = (iframe: HTMLIFrameElement) => void;
+
+/**
+ * Converts a dict of styles into HTML acceptable style string
+ * @param styles Record<string, string|number>
+ * @returns string
+ */
+export function toHTMLStyle(styles: Record<string, string | number>): string {
+  return Object.keys(styles).reduce((str, key) => {
+    const style = styles[key];
+    return (str += `${key}:${style};`);
+  }, "");
+}
+
+export enum Events {
+  ModalOpen = "modal:open",
+  ModalClose = "modal:close",
+  WalletOpened = "wallet:open",
+  WalletClosed = "wallet:close",
+  WalletLoaded = "wallet:loaded",
+  LayoutChanged = "layout:changed",
+  NotificationUpdate = "notifications:update",
+}
+
+export const MODAL_IFRAME_NAME = "mash_modal";
+
+/**
+ * A full screen modal iframe
+ */
+export class ModalIFrame {
+  readonly src: URL;
+
+  private _mounted = false;
+  get mounted() {
+    return this._mounted;
+  }
+  private set mounted(val: boolean) {
+    this._mounted = val;
+  }
+
+  private container: HTMLDivElement;
+  private iframe: HTMLIFrameElement;
+
+  private engine: PostMessageEngine<EventMessage> | null = null;
+
+  constructor(src: string) {
+    this.src = new URL(src);
+
+    this.container = document.createElement("div");
+    this.container.setAttribute("style", toHTMLStyle(CONTAINER_STYLE));
+
+    this.iframe = document.createElement("iframe");
+    this.iframe.setAttribute("title", "Mash Pre-Boarding");
+    this.iframe.setAttribute("style", toHTMLStyle(IFRAME_STYLE));
+    this.iframe.setAttribute("name", MODAL_IFRAME_NAME);
+    this.iframe.setAttribute("src", src);
+    this.iframe.allowFullscreen = true;
+  }
+
+  /**
+   * Show full screen modal
+   */
+  private showModal = () => {
+    this.container.style.visibility = "visible";
+  };
+
+  /**
+   * Close full screen modal
+   */
+  private hideModal = () => {
+    this.container.style.visibility = "hidden";
+  };
+
+  /**
+   * Setup post message tunnel between the host site and the Mash Wallet
+   */
+  private setupPostMessageEngine = () => {
+    this.engine?.listen(evt => {
+      const { data } = evt;
+
+      // If event comes in without any data, ignore it. Malformed event or
+      // something we don't care about
+      if (!data) return;
+
+      switch (data.name) {
+        case Events.ModalOpen: {
+          this.showModal();
+          break;
+        }
+        case Events.ModalClose: {
+          this.hideModal();
+          break;
+        }
+      }
+    });
+  };
+
+  /**
+   * Mount the iframes and load the Mash Wallet. Accepts a callback that triggered
+   * when the Wallet has loaded
+   * @param onLoad OnLoadCallback
+   */
+  mount() {
+    if (!this.mounted) {
+      this.container.appendChild(this.iframe);
+      document.body.appendChild(this.container);
+
+      this.mounted = true;
+    }
+
+    this.engine = new PostMessageEngine({
+      name: Targets.HostSiteFrame,
+      targetName: Targets.Modal,
+      targetWindow: this.iframe.contentWindow,
+      targetOrigin: this.src.origin,
+      targetWindowFilter: false,
+    });
+
+    this.setupPostMessageEngine();
+  }
+}

--- a/packages/client-sdk/src/iframe/ModalIFrame.ts
+++ b/packages/client-sdk/src/iframe/ModalIFrame.ts
@@ -1,5 +1,11 @@
 import PostMessageEngine from "@getmash/post-message";
-import { EventMessage, Events, MAX_Z_INDEX, Targets, toHTMLStyle } from "./blocks.js";
+import {
+  EventMessage,
+  Events,
+  MAX_Z_INDEX,
+  Targets,
+  toHTMLStyle,
+} from "./blocks.js";
 
 const CONTAINER_STYLE = {
   border: "none",

--- a/packages/client-sdk/src/iframe/ModalIFrame.ts
+++ b/packages/client-sdk/src/iframe/ModalIFrame.ts
@@ -1,6 +1,5 @@
 import PostMessageEngine from "@getmash/post-message";
-
-const MAX_Z_INDEX = 2147483647;
+import { EventMessage, Events, MAX_Z_INDEX, Targets, toHTMLStyle } from "./blocks.js";
 
 const CONTAINER_STYLE = {
   border: "none",
@@ -21,41 +20,7 @@ const IFRAME_STYLE = {
   "color-scheme": "normal",
 };
 
-export enum Targets {
-  HostSiteFrame = "@mash/host-site-iframe",
-  Modal = "@mash/modal",
-}
-
-export type EventMessage<T = Record<string, unknown>> = {
-  name: string;
-  metadata: T;
-};
-
-export type OnLoadCallback = (iframe: HTMLIFrameElement) => void;
-
-/**
- * Converts a dict of styles into HTML acceptable style string
- * @param styles Record<string, string|number>
- * @returns string
- */
-export function toHTMLStyle(styles: Record<string, string | number>): string {
-  return Object.keys(styles).reduce((str, key) => {
-    const style = styles[key];
-    return (str += `${key}:${style};`);
-  }, "");
-}
-
-export enum Events {
-  ModalOpen = "modal:open",
-  ModalClose = "modal:close",
-  WalletOpened = "wallet:open",
-  WalletClosed = "wallet:close",
-  WalletLoaded = "wallet:loaded",
-  LayoutChanged = "layout:changed",
-  NotificationUpdate = "notifications:update",
-}
-
-export const MODAL_IFRAME_NAME = "mash_modal";
+const MODAL_IFRAME_NAME = "mash_modal";
 
 /**
  * A full screen modal iframe

--- a/packages/client-sdk/src/iframe/PreboardingIFrame.ts
+++ b/packages/client-sdk/src/iframe/PreboardingIFrame.ts
@@ -27,12 +27,12 @@ const IFRAME_STYLE = {
   "color-scheme": "normal",
 };
 
-const MODAL_IFRAME_NAME = "mash_modal";
+const IFRAME_NAME = "mash_preboarding";
 
 /**
- * A full screen modal iframe
+ * A full screen iframe used to preboard users
  */
-export class ModalIFrame {
+export class PreboardingIFrame {
   readonly src: URL;
 
   private _mounted = false;
@@ -57,22 +57,22 @@ export class ModalIFrame {
     this.iframe = document.createElement("iframe");
     this.iframe.setAttribute("title", "Mash Pre-Boarding");
     this.iframe.setAttribute("style", toHTMLStyle(IFRAME_STYLE));
-    this.iframe.setAttribute("name", MODAL_IFRAME_NAME);
+    this.iframe.setAttribute("name", IFRAME_NAME);
     this.iframe.setAttribute("src", src);
     this.iframe.allowFullscreen = true;
   }
 
   /**
-   * Show full screen modal
+   * Show full screen iframe
    */
-  private showModal = () => {
+  private showPreboarding = () => {
     this.container.style.visibility = "visible";
   };
 
   /**
-   * Close full screen modal
+   * Close full screen iframe
    */
-  private hideModal = () => {
+  private hidePreboarding = () => {
     this.container.style.visibility = "hidden";
   };
 
@@ -88,12 +88,12 @@ export class ModalIFrame {
       if (!data) return;
 
       switch (data.name) {
-        case Events.ModalOpen: {
-          this.showModal();
+        case Events.PreboardingOpen: {
+          this.showPreboarding();
           break;
         }
-        case Events.ModalClose: {
-          this.hideModal();
+        case Events.PreboardingClose: {
+          this.hidePreboarding();
           break;
         }
       }
@@ -115,7 +115,7 @@ export class ModalIFrame {
 
     this.engine = new PostMessageEngine({
       name: Targets.HostSiteFrame,
-      targetName: Targets.Modal,
+      targetName: Targets.Preboard,
       targetWindow: this.iframe.contentWindow,
       targetOrigin: this.src.origin,
       targetWindowFilter: false,

--- a/packages/client-sdk/src/iframe/blocks.ts
+++ b/packages/client-sdk/src/iframe/blocks.ts
@@ -1,8 +1,8 @@
 export const MAX_Z_INDEX = 2147483647;
 
 export enum Events {
-  ModalOpen = "modal:open",
-  ModalClose = "modal:close",
+  PreboardingOpen = "preboarding:open",
+  PreboardingClose = "preboarding:close",
   WalletOpened = "wallet:open",
   WalletClosed = "wallet:close",
   WalletLoaded = "wallet:loaded",
@@ -13,7 +13,7 @@ export enum Events {
 export enum Targets {
   HostSiteFrame = "@mash/host-site-iframe",
   Wallet = "@mash/wallet",
-  Modal = "@mash/modal",
+  Preboard = "@mash/preboarding",
 }
 
 export type EventMessage<T = Record<string, unknown>> = {

--- a/packages/client-sdk/src/iframe/blocks.ts
+++ b/packages/client-sdk/src/iframe/blocks.ts
@@ -11,10 +11,10 @@ export enum Events {
 }
 
 export enum Targets {
-    HostSiteFrame = "@mash/host-site-iframe",
-    Wallet = "@mash/wallet",
-    Modal = "@mash/modal",
-  }
+  HostSiteFrame = "@mash/host-site-iframe",
+  Wallet = "@mash/wallet",
+  Modal = "@mash/modal",
+}
 
 export type EventMessage<T = Record<string, unknown>> = {
   name: string;

--- a/packages/client-sdk/src/iframe/blocks.ts
+++ b/packages/client-sdk/src/iframe/blocks.ts
@@ -1,0 +1,36 @@
+export const MAX_Z_INDEX = 2147483647;
+
+export enum Events {
+  ModalOpen = "modal:open",
+  ModalClose = "modal:close",
+  WalletOpened = "wallet:open",
+  WalletClosed = "wallet:close",
+  WalletLoaded = "wallet:loaded",
+  LayoutChanged = "layout:changed",
+  NotificationUpdate = "notifications:update",
+}
+
+export enum Targets {
+    HostSiteFrame = "@mash/host-site-iframe",
+    Wallet = "@mash/wallet",
+    Modal = "@mash/modal",
+  }
+
+export type EventMessage<T = Record<string, unknown>> = {
+  name: string;
+  metadata: T;
+};
+
+export type OnLoadCallback = (iframe: HTMLIFrameElement) => void;
+
+/**
+ * Converts a dict of styles into HTML acceptable style string
+ * @param styles Record<string, string|number>
+ * @returns string
+ */
+export function toHTMLStyle(styles: Record<string, string | number>): string {
+  return Object.keys(styles).reduce((str, key) => {
+    const style = styles[key];
+    return (str += `${key}:${style};`);
+  }, "");
+}

--- a/packages/client-sdk/src/index.ts
+++ b/packages/client-sdk/src/index.ts
@@ -15,8 +15,11 @@ export {
 } from "./iframe/position.js";
 
 export {
-  Events as IFrameEvents,
   IFRAME_NAME as MashIFrameName,
 } from "./iframe/IFrame.js";
+
+export {
+  Events as IFrameEvents,
+} from "./iframe/blocks.js";
 
 export { MashEvent } from "./events.js";

--- a/packages/client-sdk/src/index.ts
+++ b/packages/client-sdk/src/index.ts
@@ -14,12 +14,8 @@ export {
   MobileSettings,
 } from "./iframe/position.js";
 
-export {
-  IFRAME_NAME as MashIFrameName,
-} from "./iframe/IFrame.js";
+export { IFRAME_NAME as MashIFrameName } from "./iframe/IFrame.js";
 
-export {
-  Events as IFrameEvents,
-} from "./iframe/blocks.js";
+export { Events as IFrameEvents } from "./iframe/blocks.js";
 
 export { MashEvent } from "./events.js";


### PR DESCRIPTION
## Description

Adds a modal iframe that gets mounted in hidden visibility with the ability to show via a modal open event.

## Additional Info

### Testing Completed

- Checked new modal events are sent and received as expected
- Spot checked events behave as expected for existing functionality

### Client
- Removed the target window filter check in Iframe.ts post message initialization. Open to suggestions on how to avoid or minimize this particular change, but after much time spent debugging and developing this feature I ended up needing to disable it.

### To Do
- [x] Split Iframe into two, with one new iframe class for this modal