### PR TITLE
Add console log to resource failure

### DIFF
--- a/.changeset/funny-hats-guess.md
+++ b/.changeset/funny-hats-guess.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": patch
+---
+
+Add console log for easier debugging setting up IDs

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -186,7 +186,13 @@ class Mash {
     return this.rpcAPI
       .access(resourceID)
       .then(res => res.hasAccess)
-      .catch(() => false);
+      .catch(err => {
+        console.warn(
+          "[MASH] Error when attempting access, is this the correct resource ID?\n",
+          err,
+        );
+        return false;
+      });
   }
 
   /**


### PR DESCRIPTION
Add a console log message for the most common scenario of wrong resource ID.