### PR TITLE
Add excluded domain list to page matcher

### DIFF
--- a/.changeset/polite-plums-fly.md
+++ b/.changeset/polite-plums-fly.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": patch
+---
+
+Add excluded domain list for page matcher

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -98,6 +98,7 @@ class Mash {
         if (result.customization.boostConfigurations) {
           injectFloatingBoosts(
             result.customization.boostConfigurations,
+            window.location.host,
             window.location.pathname,
           );
         }
@@ -105,6 +106,7 @@ class Mash {
         if (result.customization.pageRevealers) {
           injectPageRevealers(
             result.customization.pageRevealers,
+            window.location.host,
             window.location.pathname,
           );
         }

--- a/packages/client-sdk/src/widgets/boost.ts
+++ b/packages/client-sdk/src/widgets/boost.ts
@@ -8,12 +8,18 @@ import { pageSelected } from "./pageMatcher.js";
  */
 export default function injectFloatingBoosts(
   boostConfigurations: BoostConfiguration[],
+  hostname: string,
   pathname: string,
 ) {
   boostConfigurations.forEach(config => {
     if (
       config.active &&
-      pageSelected(pathname, config.pages.target, config.pages.matchers)
+      pageSelected(
+        hostname,
+        pathname,
+        config.pages.target,
+        config.pages.matchers,
+      )
     ) {
       const boost = window.document.createElement("mash-boost-button");
       // these must be floating boosts

--- a/packages/client-sdk/src/widgets/pageMatcher.test.ts
+++ b/packages/client-sdk/src/widgets/pageMatcher.test.ts
@@ -5,13 +5,30 @@ import { MatchType, PageTarget } from "../api/routes.js";
 import { pageSelected } from "./pageMatcher.js";
 
 describe("boosts", () => {
+  it("excluded domain, page selected should be false", () => {
+    assert.ok(
+      !pageSelected("wallet.getmash.com", "/test/path", PageTarget.All, []),
+    );
+    assert.ok(
+      !pageSelected(
+        "mash-widget-dev.web.app",
+        "/test/path",
+        PageTarget.All,
+        [],
+      ),
+    );
+    assert.ok(
+      !pageSelected("localhost:3001", "/test/path", PageTarget.All, []),
+    );
+  });
+
   it("page selected target all is always true", () => {
-    assert.ok(pageSelected("/test/path", PageTarget.All, []));
+    assert.ok(pageSelected("test.com", "/test/path", PageTarget.All, []));
   });
 
   it("page selected target include is match", () => {
     assert.ok(
-      pageSelected("/test/path", PageTarget.Include, [
+      pageSelected("test.com", "/test/path", PageTarget.Include, [
         {
           id: "1",
           matchType: MatchType.Equals,
@@ -21,7 +38,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      !pageSelected("/test/path", PageTarget.Include, [
+      !pageSelected("test.com", "/test/path", PageTarget.Include, [
         {
           id: "1",
           matchType: MatchType.Equals,
@@ -31,7 +48,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      pageSelected("/test/path", PageTarget.Include, [
+      pageSelected("test.com", "/test/path", PageTarget.Include, [
         {
           id: "1",
           matchType: MatchType.StartsWith,
@@ -41,7 +58,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      !pageSelected("/test/path", PageTarget.Include, [
+      !pageSelected("test.com", "/test/path", PageTarget.Include, [
         {
           id: "1",
           matchType: MatchType.StartsWith,
@@ -51,7 +68,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      pageSelected("/test/path", PageTarget.Include, [
+      pageSelected("test.com", "/test/path", PageTarget.Include, [
         {
           id: "1",
           matchType: MatchType.Contains,
@@ -61,7 +78,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      !pageSelected("/test/path", PageTarget.Include, [
+      !pageSelected("test.com", "/test/path", PageTarget.Include, [
         {
           id: "1",
           matchType: MatchType.Contains,
@@ -73,7 +90,7 @@ describe("boosts", () => {
 
   it("page selected target include is match with multiple matchers", () => {
     assert.ok(
-      pageSelected("/test/path", PageTarget.Include, [
+      pageSelected("test.com", "/test/path", PageTarget.Include, [
         {
           id: "1",
           matchType: MatchType.Contains,
@@ -90,7 +107,7 @@ describe("boosts", () => {
 
   it("page selected target exclude is match inverse", () => {
     assert.ok(
-      !pageSelected("/test/path", PageTarget.Exclude, [
+      !pageSelected("test.com", "/test/path", PageTarget.Exclude, [
         {
           id: "1",
           matchType: MatchType.Equals,
@@ -100,7 +117,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      pageSelected("/test/path", PageTarget.Exclude, [
+      pageSelected("test.com", "/test/path", PageTarget.Exclude, [
         {
           id: "1",
           matchType: MatchType.Equals,
@@ -110,7 +127,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      !pageSelected("/test/path", PageTarget.Exclude, [
+      !pageSelected("test.com", "/test/path", PageTarget.Exclude, [
         {
           id: "1",
           matchType: MatchType.StartsWith,
@@ -120,7 +137,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      pageSelected("/test/path", PageTarget.Exclude, [
+      pageSelected("test.com", "/test/path", PageTarget.Exclude, [
         {
           id: "1",
           matchType: MatchType.StartsWith,
@@ -130,7 +147,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      !pageSelected("/test/path", PageTarget.Exclude, [
+      !pageSelected("test.com", "/test/path", PageTarget.Exclude, [
         {
           id: "1",
           matchType: MatchType.Contains,
@@ -140,7 +157,7 @@ describe("boosts", () => {
     );
 
     assert.ok(
-      pageSelected("/test/path", PageTarget.Exclude, [
+      pageSelected("test.com", "/test/path", PageTarget.Exclude, [
         {
           id: "1",
           matchType: MatchType.Contains,

--- a/packages/client-sdk/src/widgets/pageMatcher.ts
+++ b/packages/client-sdk/src/widgets/pageMatcher.ts
@@ -1,5 +1,11 @@
 import { MatchType, PageMatcher, PageTarget } from "../api/routes.js";
 
+const EXCLUDED_DOMAINS = [
+  "wallet.getmash.com",
+  "mash-widget-dev.web.app",
+  "localhost:3001",
+];
+
 /**
  * Page matched if any matcher returns true.
  */
@@ -22,13 +28,16 @@ function pageMatched(pathname: string, matchers: PageMatcher[]): boolean {
 }
 
 /**
- * Determine if page is selected to load boosts.
+ * Determine if page is selected
  */
 export function pageSelected(
+  hostname: string,
   pathname: string,
   target: PageTarget,
   matchers: PageMatcher[],
 ): boolean {
+  if (EXCLUDED_DOMAINS.includes(hostname)) return false;
+
   if (target == PageTarget.All) {
     return true;
   } else if (target == PageTarget.Exclude) {

--- a/packages/client-sdk/src/widgets/pageRevealer.ts
+++ b/packages/client-sdk/src/widgets/pageRevealer.ts
@@ -8,12 +8,18 @@ import { pageSelected } from "./pageMatcher.js";
  */
 export default function injectPageRevealers(
   pageRevealers: PageRevealer[],
+  hostname: string,
   pathname: string,
 ) {
   pageRevealers.forEach(config => {
     if (
       config.active &&
-      pageSelected(pathname, config.pages.target, config.pages.matchers)
+      pageSelected(
+        hostname,
+        pathname,
+        config.pages.target,
+        config.pages.matchers,
+      )
     ) {
       const pageRevealer = window.document.createElement("mash-page-revealer");
       pageRevealer.setAttribute("template", toAttributeStyle(config.template));


### PR DESCRIPTION
## Description

- Added excluded domain list to prevent boosts and page matcher from appearing on Mash App pages.

Closes https://github.com/getmash/mash/issues/1738
