### PR TITLE
Load preboarding iframe after main

### DIFF
--- a/.changeset/yellow-dolphins-hope.md
+++ b/.changeset/yellow-dolphins-hope.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": patch
+---
+
+Load preboarding iframe after main iframe

--- a/packages/client-sdk/src/Mash.ts
+++ b/packages/client-sdk/src/Mash.ts
@@ -263,10 +263,12 @@ class Mash {
             resolve(null);
           })
           .catch(err => reject(err));
+
+        // Mount other dependent iframes
+        this.preboardIFrame.mount();
       };
 
       this.iframe.mount(onIframeLoaded, position);
-      this.preboardIFrame.mount();
     });
   }
 }


### PR DESCRIPTION
## Description

Loads/mounts preboarding iframe only after main iframe is done loading

## Additional Info

### Linked GitHub Tickets

### Testing Completed

- Tested iframe and widgets in clickabutton behave as expected
- Tested preboarding iframe can always access earner data which was previously spotty
