### PR TITLE
Add key property to injected page revealer

### DIFF
--- a/.changeset/good-lies-lay.md
+++ b/.changeset/good-lies-lay.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": patch
+---
+
+Bugfix: Add key property to injected page revealer

--- a/packages/client-sdk/src/api/routes.ts
+++ b/packages/client-sdk/src/api/routes.ts
@@ -85,6 +85,7 @@ export type BoostConfiguration = {
 };
 
 export type PageRevealer = {
+  id: string;
   active: boolean;
   pages: PageSelection;
   contentTypeID: string;

--- a/packages/client-sdk/src/widgets/pageRevealer.ts
+++ b/packages/client-sdk/src/widgets/pageRevealer.ts
@@ -65,6 +65,10 @@ export default function injectPageRevealers(
       // tie to content type
       pageRevealer.setAttribute("resource", config.contentTypeID);
 
+      // set key to track when user accessed
+      const key = `mash-${config.id}-${pathname}`;
+      pageRevealer.setAttribute("key", key);
+
       // inject onto site
       document.body.appendChild(pageRevealer);
     }

--- a/packages/client-sdk/src/widgets/pageRevealer.ts
+++ b/packages/client-sdk/src/widgets/pageRevealer.ts
@@ -66,7 +66,7 @@ export default function injectPageRevealers(
       pageRevealer.setAttribute("resource", config.contentTypeID);
 
       // set key to track when user accessed
-      const key = `mash-${config.id}-${pathname}`;
+      const key = `${config.id}-${pathname}`;
       pageRevealer.setAttribute("key", key);
 
       // inject onto site


### PR DESCRIPTION
## Description

- The injected page revealer was not using the `key` to provide a cache for completed payments for users.