### PR TITLE
Drop exploding postmessage log line

### DIFF
--- a/.changeset/cold-crabs-greet.md
+++ b/.changeset/cold-crabs-greet.md
@@ -1,0 +1,5 @@
+---
+"@getmash/post-message": patch
+---
+
+Fix log line from blowing up on ignored message

--- a/packages/post-message/src/PostMessageEngine.ts
+++ b/packages/post-message/src/PostMessageEngine.ts
@@ -81,9 +81,7 @@ export default class PostMessageEngine<TData> {
     }
     // checking the event source helps limit messages and can also be used as a secondary security check
     if (this._targetWindowFilter && this._targetWindow !== evt.source) {
-      this._logger(
-        `${this.name} engine ignored message due to window, message: ${evt.source} engine: ${this._targetWindow}`,
-      );
+      this._logger(`${this.name} engine ignored message due to window`);
       return true;
     }
 


### PR DESCRIPTION
Ric pointed out that this log line is trying to turn a full on window into a string and that upsets things. I tried to find a useful property to log instead, but the typings are weird and nothing really worked, so just dropping for now.

Tested locally by linking the repos.