### PR TITLE
Fix typo in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.MASH_JS_PAT }}
+          token: ${{ secrets.MASH_JS_PAT }}
       
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        env:
+        with:
           GITHUB_TOKEN: ${{ secrets.MASH_JS_PAT }}
       
       - name: Use Node.js


### PR DESCRIPTION
Trying to get the PAT working in the `main` workflow so it can run CI jobs, noticed I had a  typo in the checkout config.