### PR TITLE
Fix position fixed breaking site layout

### DIFF
--- a/.changeset/large-mayflies-pretend.md
+++ b/.changeset/large-mayflies-pretend.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": patch
+---
+
+Prevent background scroll by using height + overflow

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -202,7 +202,6 @@ export default class IFrame {
       document.body.style.height = "100vh";
       document.body.style.overflowY = "hidden";
     }
-    
   }
 
   /**

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -195,6 +195,27 @@ export default class IFrame {
   };
 
   /**
+   * Add style settings to host site to prevent it from scrolling on mobile
+   */
+  private preventBackgroundScroll() {
+    if (this.getMediaQuery().matches) {
+      document.body.style.height = "100vh";
+      document.body.style.overflowY = "hidden";
+    }
+    
+  }
+
+  /**
+   * Clear out style settings to host site that prevent it from scrolling on mobile
+   */
+  private resetBackgroundScroll() {
+    if (this.getMediaQuery().matches) {
+      document.body.style.height = "";
+      document.body.style.overflowY = "";
+    }
+  }
+
+  /**
    * Retrieve mediaQueryList for the given mediaQuery that changes the layout
    * of the iframe container.
    */
@@ -265,12 +286,14 @@ export default class IFrame {
       switch (data.name) {
         case Events.WalletOpened: {
           this.open = true;
+          this.preventBackgroundScroll();
           this.resize();
           this.position();
           break;
         }
         case Events.WalletClosed: {
           this.open = false;
+          this.resetBackgroundScroll();
           this.resize();
           this.position();
           break;

--- a/packages/client-sdk/src/iframe/PreboardingIFrame.ts
+++ b/packages/client-sdk/src/iframe/PreboardingIFrame.ts
@@ -43,9 +43,6 @@ export class PreboardingIFrame {
 
   private engine: PostMessageEngine<EventMessage> | null = null;
 
-  private scrollElement: HTMLElement;
-  private scrollTop: number;
-
   constructor(src: string) {
     this.src = new URL(src);
 
@@ -58,9 +55,6 @@ export class PreboardingIFrame {
     this.iframe.setAttribute("name", IFRAME_NAME);
     this.iframe.setAttribute("src", src);
     this.iframe.allowFullscreen = true;
-
-    this.scrollElement = document.documentElement || document.body;
-    this.scrollTop = this.scrollElement.scrollTop;
   }
 
   /**
@@ -70,11 +64,9 @@ export class PreboardingIFrame {
     // Make modal visible
     this.container.style.visibility = "visible";
 
-    // Update user's currently scrolled position
-    this.scrollTop = this.scrollElement.scrollTop;
-
     // Prevent background from scrolling
-    document.body.style.position = "fixed";
+    document.body.style.height = "100vh";
+    document.body.style.overflowY = "hidden";
   };
 
   /**
@@ -84,9 +76,9 @@ export class PreboardingIFrame {
     // Hide modal visibility
     this.container.style.visibility = "hidden";
 
-    // Revert background to its original position value
-    document.body.style.position = "";
-    this.scrollElement.scrollTop = this.scrollTop;
+    // Revert background to its original values
+    document.body.style.height = "";
+    document.body.style.overflowY = "";
   };
 
   /**


### PR DESCRIPTION
## Description

Using a fixed position breaks the site layout on some host sites. Try setting height to full viewport plus hidden overflow to achieve the same while retaining host site layout as much as possible.

## Additional Info

### Testing Completed

- Manually tested these settings on sites that were shown to break with position fixed
- Manually tested settings on sites that did not break with position fixed
- Tested on clickabutton for preboarding open/close
- Tested on clickabutton for mash button open/close