### PR TITLE
Load mash elements based on mash button url

### DIFF
--- a/.changeset/rich-rice-arrive.md
+++ b/.changeset/rich-rice-arrive.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": minor
+---
+
+Load mash elements based on mash button domain

--- a/packages/client-sdk/src/config.test.ts
+++ b/packages/client-sdk/src/config.test.ts
@@ -1,26 +1,20 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import parse, {
-  Config,
-  DefaultAPIBaseURL,
-  DefaultPreboardingURL,
-  DefaultWalletURL,
-  DefaultWidgetBaseURL,
-} from "./config.js";
+import parse, { Config, DefaultMashButtonURL } from "./config.js";
 
 describe("Config", () => {
   it("empty config passed in, should set defaults", () => {
     const result = parse({ earnerID: "1" });
     assert.deepEqual<Config>(result, {
-      api: DefaultAPIBaseURL,
+      api: "https://api.mash.com",
       autoHide: undefined,
       mashButtonPosition: undefined,
       earnerID: "1",
-      walletURL: DefaultWalletURL,
-      preboardingURL: DefaultPreboardingURL,
+      walletURL: DefaultMashButtonURL,
+      preboardingURL: "https://app.mash.com/preboarding",
       widgets: {
-        baseURL: DefaultWidgetBaseURL,
+        baseURL: "https://widgets.mash.com",
         injectTheme: true,
         injectWebComponentScripts: true,
         injectFloatingWidgets: true,
@@ -34,8 +28,8 @@ describe("Config", () => {
       earnerID: "1",
       autoHide: undefined,
       mashButtonPosition: undefined,
-      walletURL: "testsite",
-      preboardingURL: "testpreboardingsite",
+      walletURL: "https://testsite.com/",
+      preboardingURL: "https://testsite.com/preboarding",
       widgets: {
         baseURL: "tester.com",
         injectTheme: false,
@@ -45,6 +39,27 @@ describe("Config", () => {
     };
     const result = parse(config);
     assert.deepEqual<Config>(result, config);
+  });
+
+  it("custom config, should throw error if given url has invalid format", () => {
+    const config: Config = {
+      api: "test.com",
+      earnerID: "1",
+      autoHide: undefined,
+      mashButtonPosition: undefined,
+      walletURL: "testsite.com",
+      preboardingURL: "testsite.com/preboarding",
+      widgets: {
+        baseURL: "tester.com",
+        injectTheme: false,
+        injectWebComponentScripts: false,
+        injectFloatingWidgets: false,
+      },
+    };
+
+    assert.throws(() => {
+      parse(config);
+    }, Error);
   });
 
   it("custom config, support injectWidgets value", () => {

--- a/packages/client-sdk/src/config.ts
+++ b/packages/client-sdk/src/config.ts
@@ -105,20 +105,20 @@ function parseURL(url: string): URL | null {
 
 export default function parse(config: PartialConfig): Config {
   // This URL is used to build all other URLS in the config, to ensure all Mash elements live in the same domain
-  const mainURL = parseURL(config.walletURL || DefaultMashButtonURL);
+  const mashButtonURL = parseURL(config.walletURL || DefaultMashButtonURL);
 
-  if (mainURL === null) {
+  if (mashButtonURL === null) {
     throw new Error(
       "Not a valid URL. Expecting a format like: https://example.com, https://sub.example.com",
     );
   }
+
   // Allow API URL to be overriden in case the API has a different domain
-  const apiURL = config.api || buildSubdomainURL(mainURL, "api");
-  const mashButtonURL = mainURL.href;
-  const preboardingURL = `${mainURL.protocol}//${mainURL.host}/preboarding`;
+  const apiURL = config.api || buildSubdomainURL(mashButtonURL, "api");
+  const preboardingURL = `${mashButtonURL.protocol}//${mashButtonURL.host}/preboarding`;
 
   const defaultWidgetsConfig: WidgetConfig = {
-    baseURL: buildSubdomainURL(mainURL, "widgets"),
+    baseURL: buildSubdomainURL(mashButtonURL, "widgets"),
     injectTheme: true,
     injectWebComponentScripts: true,
     injectFloatingWidgets: true,
@@ -127,7 +127,7 @@ export default function parse(config: PartialConfig): Config {
   return {
     earnerID: config.earnerID,
     api: apiURL,
-    walletURL: mashButtonURL,
+    walletURL: mashButtonURL.href,
     preboardingURL,
     widgets: { ...defaultWidgetsConfig, ...config.widgets },
     autoHide: config.autoHide,

--- a/packages/client-sdk/src/config.ts
+++ b/packages/client-sdk/src/config.ts
@@ -109,7 +109,7 @@ export default function parse(config: PartialConfig): Config {
 
   if (mainURL === null) {
     throw new Error(
-      "Not a valid URL. Expecting this format: https://example.com",
+      "Not a valid URL. Expecting a format like: https://example.com, https://sub.example.com",
     );
   }
   // Allow API URL to be overriden in case the API has a different domain

--- a/packages/client-sdk/src/config.ts
+++ b/packages/client-sdk/src/config.ts
@@ -51,7 +51,8 @@ export type Config = {
    */
   walletURL: string;
   /**
-   * Mash Preboadring Modal App URL.
+   * Mash Preboarding Modal App URL.
+   * @deprecated url is constructed from wallet url
    */
   preboardingURL: string;
   /**


### PR DESCRIPTION
## Description

Load Mash elements based on mash button domain. This ensures all elements are on the same domain and can communicate without issues.

If an invalid url is given as the wallet button url in MashSettings then the sdk will throw with a message

## Additional Info

### Client
- Deprecate preboardingURL as a config parameter, still used internally
- Updates tests

### Linked GitHub Tickets

- mash-js #107

### Testing Completed

- I tested on clickabutton: wallet loads, preboarding shows, widgets work, payments work
