### PR TITLE
Fix mobile wallet button position expecting a custom shift parameter

### DIFF
--- a/.changeset/fifty-apricots-return.md
+++ b/.changeset/fifty-apricots-return.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": patch
+---
+
+Fix mobile wallet button position expecting a customShift parameter. Mobile does not support this property"

--- a/packages/client-sdk/src/api/routes.test.ts
+++ b/packages/client-sdk/src/api/routes.test.ts
@@ -5,7 +5,8 @@ import {
   defaultEarnerCustomizationConfig,
   EarnerCustomizationConfiguration,
   mergeEarnerCustomizationConfig,
-  WalletButtonDevicePosition,
+  WalletButtonDesktopPosition,
+  WalletButtonMobilePosition,
   WalletButtonFloatPlacement,
   WalletButtonFloatSide,
 } from "./routes.js";
@@ -30,16 +31,15 @@ describe("routes", () => {
       assert.equal(result.autoHide, true);
     });
     it("merge default with position override, should match position override", () => {
-      const desktop: WalletButtonDevicePosition = {
+      const desktop: WalletButtonDesktopPosition = {
         floatPlacement: WalletButtonFloatPlacement.Intercom,
         floatSide: WalletButtonFloatSide.Left,
         customShiftConfiguration: { horizontal: 5, vertical: 10 },
       };
 
-      const mobile: WalletButtonDevicePosition = {
+      const mobile: WalletButtonMobilePosition = {
         floatPlacement: WalletButtonFloatPlacement.Ghost,
         floatSide: WalletButtonFloatSide.Left,
-        customShiftConfiguration: { horizontal: 15, vertical: 152 },
       };
 
       const result = mergeEarnerCustomizationConfig(

--- a/packages/client-sdk/src/api/routes.ts
+++ b/packages/client-sdk/src/api/routes.ts
@@ -37,15 +37,20 @@ export type WalletButtonShiftConfiguration = {
   vertical: number;
 };
 
-export type WalletButtonDevicePosition = {
+export type WalletButtonDesktopPosition = {
   floatSide: WalletButtonFloatSide;
   floatPlacement: WalletButtonFloatPlacement;
   customShiftConfiguration: WalletButtonShiftConfiguration;
 };
 
+export type WalletButtonMobilePosition = Omit<
+  WalletButtonDesktopPosition,
+  "customShiftConfiguration"
+>;
+
 export type WalletButtonPosition = {
-  desktop: WalletButtonDevicePosition;
-  mobile: WalletButtonDevicePosition;
+  desktop: WalletButtonDesktopPosition;
+  mobile: WalletButtonMobilePosition;
 };
 
 export type BoostDesktopConfiguration = {
@@ -128,7 +133,6 @@ export const defaultEarnerCustomizationConfig: EarnerCustomizationConfiguration 
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: { horizontal: 0, vertical: 0 },
       },
     },
     theme: {
@@ -145,25 +149,6 @@ type NotOverridableConfig = Omit<
   "autoHide" | "walletButtonPosition"
 >;
 
-function mergeDeviceConfig(
-  config: WalletButtonDevicePosition,
-  override?: PartialDeep<WalletButtonDevicePosition>,
-): WalletButtonDevicePosition {
-  if (!override) return config;
-  return {
-    floatSide: override.floatSide || config.floatSide,
-    floatPlacement: override.floatPlacement || config.floatPlacement,
-    customShiftConfiguration: {
-      horizontal:
-        override.customShiftConfiguration?.horizontal ||
-        config.customShiftConfiguration.horizontal,
-      vertical:
-        override.customShiftConfiguration?.vertical ||
-        config.customShiftConfiguration.vertical,
-    },
-  };
-}
-
 export function mergeEarnerCustomizationConfig(
   config: EarnerCustomizationConfiguration,
   overrides: PartialDeep<EarnerCustomizationConfiguration>,
@@ -177,15 +162,33 @@ export function mergeEarnerCustomizationConfig(
 
   const autoHide = overrides.autoHide ?? config.autoHide;
 
-  const desktop = mergeDeviceConfig(
-    config.walletButtonPosition.desktop,
-    overrides.walletButtonPosition?.desktop,
-  );
+  const desktop: WalletButtonDesktopPosition = {
+    floatSide:
+      overrides.walletButtonPosition?.desktop?.floatSide ||
+      config.walletButtonPosition.desktop.floatSide,
+    floatPlacement:
+      overrides.walletButtonPosition?.desktop?.floatPlacement ||
+      config.walletButtonPosition.desktop.floatPlacement,
+    customShiftConfiguration: {
+      horizontal:
+        overrides.walletButtonPosition?.desktop?.customShiftConfiguration
+          ?.horizontal ||
+        config.walletButtonPosition.desktop.customShiftConfiguration.horizontal,
+      vertical:
+        overrides.walletButtonPosition?.desktop?.customShiftConfiguration
+          ?.vertical ||
+        config.walletButtonPosition.desktop.customShiftConfiguration.vertical,
+    },
+  };
 
-  const mobile = mergeDeviceConfig(
-    config.walletButtonPosition.mobile,
-    overrides.walletButtonPosition?.mobile,
-  );
+  const mobile: WalletButtonMobilePosition = {
+    floatSide:
+      overrides.walletButtonPosition?.mobile?.floatSide ||
+      config.walletButtonPosition.mobile.floatSide,
+    floatPlacement:
+      overrides.walletButtonPosition?.mobile?.floatPlacement ||
+      config.walletButtonPosition.mobile.floatPlacement,
+  };
 
   return { ...statik, autoHide, walletButtonPosition: { desktop, mobile } };
 }

--- a/packages/client-sdk/src/api/routes.ts
+++ b/packages/client-sdk/src/api/routes.ts
@@ -37,12 +37,14 @@ export type WalletButtonShiftConfiguration = {
   vertical: number;
 };
 
+// https://github.com/getmash/mash/blob/main/platform/api/spec/mash.yaml#L1369
 export type WalletButtonDesktopPosition = {
   floatSide: WalletButtonFloatSide;
   floatPlacement: WalletButtonFloatPlacement;
   customShiftConfiguration: WalletButtonShiftConfiguration;
 };
 
+// https://github.com/getmash/mash/blob/main/platform/api/spec/mash.yaml#L1384
 export type WalletButtonMobilePosition = Omit<
   WalletButtonDesktopPosition,
   "customShiftConfiguration"

--- a/packages/client-sdk/src/iframe/IFrame.test.ts
+++ b/packages/client-sdk/src/iframe/IFrame.test.ts
@@ -150,10 +150,6 @@ describe("IFrame Events", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 100,
-        },
       },
     });
 
@@ -270,10 +266,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -298,10 +290,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -326,10 +314,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -352,10 +336,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -378,10 +358,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -407,10 +383,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -436,10 +408,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -462,10 +430,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -491,10 +455,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -520,10 +480,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -549,10 +505,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -578,10 +530,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -605,10 +553,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -634,10 +578,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -661,10 +601,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -691,10 +627,6 @@ describe("IFrame Desktop", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -724,10 +656,6 @@ describe("IFrame Mobile", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Left,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 
@@ -752,10 +680,6 @@ describe("IFrame Mobile", () => {
       mobile: {
         floatSide: WalletButtonFloatSide.Right,
         floatPlacement: WalletButtonFloatPlacement.Default,
-        customShiftConfiguration: {
-          horizontal: 0,
-          vertical: 0,
-        },
       },
     });
 

--- a/packages/client-sdk/src/iframe/position.test.ts
+++ b/packages/client-sdk/src/iframe/position.test.ts
@@ -12,7 +12,7 @@ describe("settings", () => {
   describe("merge", () => {
     it("no position setting, should set correct defaults", () => {
       const result = getWalletPosition(undefined, undefined);
-      assert.deepEqual(result, {
+      assert.deepEqual<WalletButtonPosition>(result, {
         desktop: {
           floatSide: WalletButtonFloatSide.Right,
           floatPlacement: WalletButtonFloatPlacement.Default,
@@ -24,10 +24,6 @@ describe("settings", () => {
         mobile: {
           floatSide: WalletButtonFloatSide.Right,
           floatPlacement: WalletButtonFloatPlacement.Default,
-          customShiftConfiguration: {
-            horizontal: 0,
-            vertical: 0,
-          },
         },
       });
     });
@@ -56,10 +52,6 @@ describe("settings", () => {
         mobile: {
           floatSide: WalletButtonFloatSide.Right,
           floatPlacement: WalletButtonFloatPlacement.Default,
-          customShiftConfiguration: {
-            horizontal: 50,
-            vertical: 60,
-          },
         },
       };
 

--- a/packages/client-sdk/src/iframe/position.ts
+++ b/packages/client-sdk/src/iframe/position.ts
@@ -1,9 +1,10 @@
 import { PartialDeep } from "type-fest";
 
 import {
-  WalletButtonDevicePosition,
+  WalletButtonDesktopPosition,
   WalletButtonFloatPlacement,
   WalletButtonFloatSide,
+  WalletButtonMobilePosition,
   WalletButtonPosition,
 } from "../api/routes.js";
 
@@ -80,7 +81,18 @@ function normalizeFloatPlacement(
   return location;
 }
 
-function getPositionConfig(cfg?: PartialDeep<WalletButtonDevicePosition>) {
+function getMobilePositionConfig(
+  cfg?: PartialDeep<WalletButtonMobilePosition>,
+) {
+  return {
+    floatSide: normalizeFloatSide(cfg?.floatSide),
+    floatPlacement: normalizeFloatPlacement(cfg?.floatPlacement),
+  };
+}
+
+function getDesktopPositionConfig(
+  cfg?: PartialDeep<WalletButtonDesktopPosition>,
+) {
   return {
     floatSide: normalizeFloatSide(cfg?.floatSide),
     floatPlacement: normalizeFloatPlacement(cfg?.floatPlacement),
@@ -95,12 +107,12 @@ function getPositionConfig(cfg?: PartialDeep<WalletButtonDevicePosition>) {
  * Full wallet position configuration, any missing parts have default values.
  */
 export function getWalletPosition(
-  desktop?: Partial<WalletButtonDevicePosition> | undefined,
-  mobile?: Partial<WalletButtonDevicePosition> | undefined,
+  desktop?: Partial<WalletButtonDesktopPosition> | undefined,
+  mobile?: Partial<WalletButtonMobilePosition> | undefined,
 ): WalletButtonPosition {
   return {
-    desktop: getPositionConfig(desktop),
-    mobile: getPositionConfig(mobile),
+    desktop: getDesktopPositionConfig(desktop),
+    mobile: getMobilePositionConfig(mobile),
   };
 }
 
@@ -153,13 +165,6 @@ export function getLocation(
     }
     case WalletButtonFloatPlacement.BasicShiftVertical: {
       mobileLocation.bottom = BASIC_SHIFT_VERTICAL;
-      break;
-    }
-    case WalletButtonFloatPlacement.Custom: {
-      mobileLocation.bottom = normalizeShift(
-        config.mobile.customShiftConfiguration.vertical,
-        MAX_SHIFT_VERTICAL,
-      );
       break;
     }
   }


### PR DESCRIPTION
## Description

- Prior to #110 we had 2 identical objects for Mobile + Desktop and both contained `customShiftConfiguration`. The actual API does not support a `customShiftConfiguration`. Once they were refactored into own, I noticed that it was failing because the API never returns this object and the merge would fail
- Remove code that handles mobile custom shift configuration in `position` and `iframe`
