### PR TITLE
Add a slash for easier usage in page matcher

### DIFF
--- a/packages/client-sdk/src/widgets/pageMatcher.test.ts
+++ b/packages/client-sdk/src/widgets/pageMatcher.test.ts
@@ -21,6 +21,16 @@ describe("boosts", () => {
     );
 
     assert.ok(
+      pageSelected("/test/path", PageTarget.Include, [
+        {
+          id: "1",
+          matchType: MatchType.Equals,
+          matchText: "test/path",
+        },
+      ]),
+    );
+
+    assert.ok(
       !pageSelected("/test/path", PageTarget.Include, [
         {
           id: "1",
@@ -36,6 +46,16 @@ describe("boosts", () => {
           id: "1",
           matchType: MatchType.StartsWith,
           matchText: "/test",
+        },
+      ]),
+    );
+
+    assert.ok(
+      pageSelected("/test/path", PageTarget.Include, [
+        {
+          id: "1",
+          matchType: MatchType.StartsWith,
+          matchText: "test",
         },
       ]),
     );

--- a/packages/client-sdk/src/widgets/pageMatcher.ts
+++ b/packages/client-sdk/src/widgets/pageMatcher.ts
@@ -1,15 +1,23 @@
 import { MatchType, PageMatcher, PageTarget } from "../api/routes.js";
 
 /**
+ * Ensure the match text begins with a slash for easy comparison to the pathname.
+ */
+function standardizeMatchText(matchText: string): string {
+  return matchText.startsWith("/") ? matchText : "/" + matchText;
+}
+
+/**
  * Page matched if any matcher returns true.
  */
 function pageMatched(pathname: string, matchers: PageMatcher[]): boolean {
   for (const matcher of matchers) {
     const equals =
-      matcher.matchType == MatchType.Equals && pathname === matcher.matchText;
+      matcher.matchType == MatchType.Equals &&
+      pathname === standardizeMatchText(matcher.matchText);
     const startsWith =
       matcher.matchType == MatchType.StartsWith &&
-      pathname.startsWith(matcher.matchText);
+      pathname.startsWith(standardizeMatchText(matcher.matchText));
     const contains =
       matcher.matchType == MatchType.Contains &&
       pathname.includes(matcher.matchText);


### PR DESCRIPTION
Accept user input of `/blog` or `blog` for page matching since the forward slash requirement is non-obvious and somewhat difficult to enforce upfront.