### PR TITLE
Switch to dynamic viewport units

### DIFF
--- a/.changeset/unlucky-months-beam.md
+++ b/.changeset/unlucky-months-beam.md
@@ -1,0 +1,5 @@
+---
+"@getmash/client-sdk": minor
+---
+
+Switch to dynamic viewport units

--- a/examples/mash-sdk-donate/index.html
+++ b/examples/mash-sdk-donate/index.html
@@ -10,7 +10,7 @@
             position: relative;
             margin: 0 auto;
             
-            height: 100vh;
+            height: 100dvh;
             width: 100%;
             max-width: 600px;
             

--- a/examples/mash-sdk-paywall/index.html
+++ b/examples/mash-sdk-paywall/index.html
@@ -10,7 +10,7 @@
             position: relative;
             margin: 0 auto;
             
-            height: 100vh;
+            height: 100dvh;
             width: 100%;
             max-width: 600px;
             

--- a/packages/client-sdk/src/iframe/IFrame.ts
+++ b/packages/client-sdk/src/iframe/IFrame.ts
@@ -183,7 +183,7 @@ export default class IFrame {
    */
   private preventBackgroundScroll() {
     if (this.getMediaQuery().matches) {
-      document.body.style.height = "100vh";
+      document.body.style.height = "100dvh";
       document.body.style.overflowY = "hidden";
     }
   }

--- a/packages/client-sdk/src/iframe/PreboardingIFrame.ts
+++ b/packages/client-sdk/src/iframe/PreboardingIFrame.ts
@@ -6,7 +6,7 @@ import zIndex from "./zIndex.js";
 const CONTAINER_STYLE = {
   border: "none",
   width: "100%",
-  height: "100vh",
+  height: "100dvh",
   position: "fixed",
   top: "0",
   left: "0",
@@ -65,7 +65,7 @@ export class PreboardingIFrame {
     this.container.style.visibility = "visible";
 
     // Prevent background from scrolling
-    document.body.style.height = "100vh";
+    document.body.style.height = "100dvh";
     document.body.style.overflowY = "hidden";
   };
 


### PR DESCRIPTION
This change is to allow the preboarding view to handle mobile browser toolbars better. But also updating other viewport units since I believe we always mean for them to be dynamic.