### PR TITLE
Set default semver prefix to tilde

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -11,3 +11,7 @@ plugins:
     spec: "https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js"
 
 yarnPath: .yarn/releases/yarn-3.2.3.cjs
+
+# The default prefix for semantic version dependency ranges, which is used for new dependencies that are installed to a manifest.
+# Possible values are "^" (the default), "~" or "".
+defaultSemverRangePrefix: "~"


### PR DESCRIPTION
## Description

Follow up to https://github.com/getmash/mash/pull/2744#discussion_r1264011326


## Additional Info

### Testing Completed

- Tested adding a package uses tilde, not caret.
- Tested works in packages
