### PR TITLE
Include source in event message

### DIFF
--- a/.changeset/heavy-experts-pretend.md
+++ b/.changeset/heavy-experts-pretend.md
@@ -1,0 +1,5 @@
+---
+"@getmash/post-message": minor
+---
+
+Includes the `source` property in postmessage events in what gets called back to the listener

--- a/packages/post-message/src/PostMessageEngine.test.ts
+++ b/packages/post-message/src/PostMessageEngine.test.ts
@@ -190,7 +190,7 @@ describe("PostMessageEngine", () => {
       // @ts-expect-error testing the private value
       const result = tester._shouldIgnoreMessage({
         ...validEvent,
-        data: { ...validEvent.data, targetName: "badddd", source: null },
+        data: { ...validEvent.data, targetName: "badddd" },
       });
       assert.ok(result);
     });
@@ -213,7 +213,7 @@ describe("PostMessageEngine", () => {
       const result = tester._shouldIgnoreMessage({
         ...validEvent,
         // @ts-expect-error testing the private value
-        data: { ...validEvent, data: undefined, source: null },
+        data: { ...validEvent, data: undefined },
       });
       assert.ok(result);
     });

--- a/packages/post-message/src/PostMessageEngine.test.ts
+++ b/packages/post-message/src/PostMessageEngine.test.ts
@@ -190,7 +190,7 @@ describe("PostMessageEngine", () => {
       // @ts-expect-error testing the private value
       const result = tester._shouldIgnoreMessage({
         ...validEvent,
-        data: { ...validEvent.data, targetName: "badddd" },
+        data: { ...validEvent.data, targetName: "badddd", source: null },
       });
       assert.ok(result);
     });
@@ -213,7 +213,7 @@ describe("PostMessageEngine", () => {
       const result = tester._shouldIgnoreMessage({
         ...validEvent,
         // @ts-expect-error testing the private value
-        data: { ...validEvent, data: undefined },
+        data: { ...validEvent, data: undefined, source: null },
       });
       assert.ok(result);
     });

--- a/packages/post-message/src/PostMessageEngine.ts
+++ b/packages/post-message/src/PostMessageEngine.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from "uuid";
 export type PostMessageEvent<TData = unknown> = {
   targetName: string;
   data?: TData;
+  source: MessageEventSource | null;
 };
 
 export interface PostMessageEngineOptions {
@@ -101,7 +102,7 @@ export default class PostMessageEngine<TData> {
       evt: MessageEvent<PostMessageEvent<TData>>,
     ) => {
       if (this._shouldIgnoreMessage(evt)) return;
-      listener(evt.data || null);
+      listener({ ...evt.data, source: evt.source } || null);
     };
     this._listeners[id] = wrapped;
     window.addEventListener("message", wrapped, false);

--- a/packages/post-message/src/PostMessageEngine.ts
+++ b/packages/post-message/src/PostMessageEngine.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from "uuid";
 export type PostMessageEvent<TData = unknown> = {
   targetName: string;
   data?: TData;
-  source: MessageEventSource | null;
+  source?: MessageEventSource | null;
 };
 
 export interface PostMessageEngineOptions {


### PR DESCRIPTION
## Description
Includes the source property in postmessage event object which allows message receivers to respond back to source if needed, like: `msg.source.postMessage`

There'll be a sweep after main reactions functionality is done, to clean up typings where needed and potentially move to using JsonRPCMessage instead of raw PostMessageEngine



## Additional Info

### Testing Completed

- Tested no visible regression on local puree's hub via yarn link
- Tested  hub can respond back to postmessage  using event source
